### PR TITLE
Update spec text and test cases for Stage 2 readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,39 +44,39 @@ While these approaches work, they end up being difficult to optimize because the
 
 This proposal provides three complementary static methods for concatenation:
 
-1. **`%TypedArray%.concat(items [, length])`** — element-oriented concatenation of same-type TypedArrays
-2. **`ArrayBuffer.concat(items [, options])`** — byte-oriented concatenation returning an ArrayBuffer
-3. **`SharedArrayBuffer.concat(items [, options])`** — byte-oriented concatenation returning a SharedArrayBuffer
+1. **`%TypedArray%.fromList(items [, length])`** — element-oriented concatenation of same-type TypedArrays
+2. **`ArrayBuffer.fromList(items [, options])`** — byte-oriented concatenation returning an ArrayBuffer
+3. **`SharedArrayBuffer.fromList(items [, options])`** — byte-oriented concatenation returning a SharedArrayBuffer
 
 All three methods afford implementations the ability to determine the most optimal approach, and optimal timing, for performing the allocations and copies, but no specific optimization is required.
 
-`%TypedArray%.concat` accepts only TypedArrays of the same type as the constructor (e.g., all `Uint8Array` for `Uint8Array.concat`), though those TypedArrays may be backed by either an ArrayBuffer or a SharedArrayBuffer. `ArrayBuffer.concat` and `SharedArrayBuffer.concat` accept any mix of ArrayBuffer, SharedArrayBuffer, TypedArray, and DataView inputs — the return type is determined by which method is called, not by the input types.
+`%TypedArray%.fromList` accepts only TypedArrays of the same type as the constructor (e.g., all `Uint8Array` for `Uint8Array.fromList`), though those TypedArrays may be backed by either an ArrayBuffer or a SharedArrayBuffer. `ArrayBuffer.fromList` and `SharedArrayBuffer.fromList` accept any mix of ArrayBuffer, SharedArrayBuffer, TypedArray, and DataView inputs — the return type is determined by which method is called, not by the input types.
 
-### `%TypedArray%.concat(items [, length])`
+### `%TypedArray%.fromList(items [, length])`
 
-Concatenates multiple TypedArrays of the same type into a new TypedArray.
+Creates a new TypedArray by concatenating the elements of multiple TypedArrays of the same type.
 
 ```js
 const enc = new TextEncoder();
 const u8_1 = enc.encode('Hello ');
 const u8_2 = enc.encode('World!');
-const u8_3 = Uint8Array.concat([u8_1, u8_2]);
+const u8_3 = Uint8Array.fromList([u8_1, u8_2]);
 // u8_3 contains: Uint8Array [72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]
 ```
 
 - `items` — an iterable of TypedArray instances, all of the same type as the constructor.
 - `length` (optional) — a non-negative integer specifying the element length of the result. If less than the total, the result is truncated. If greater, the result is zero-filled. Defaults to the sum of all input lengths.
 
-All items must be TypedArrays of the same type as the constructor (e.g., all `Uint8Array` for `Uint8Array.concat`). A `TypeError` is thrown if any item is a different type. Items may be backed by either an ArrayBuffer or a SharedArrayBuffer.
+All items must be TypedArrays of the same type as the constructor (e.g., all `Uint8Array` for `Uint8Array.fromList`). A `TypeError` is thrown if any item is a different type. Items may be backed by either an ArrayBuffer or a SharedArrayBuffer.
 
 A `TypeError` is thrown if any item is a detached TypedArray. A `RangeError` is thrown if the total element count exceeds 2<sup>53</sup> - 1.
 
 ```js
 // Truncate to 5 elements
-const truncated = Uint8Array.concat([u8_1, u8_2], 5);
+const truncated = Uint8Array.fromList([u8_1, u8_2], 5);
 
 // Zero-fill to 20 elements
-const padded = Uint8Array.concat([u8_1, u8_2], 20);
+const padded = Uint8Array.fromList([u8_1, u8_2], 20);
 
 // WritableStream coalescing example
 let buffers = [];
@@ -86,7 +86,7 @@ new WritableStream({
     buffers.push(chunk);
     size += chunk.length;
     if (size >= 4096) {
-      flushBuffer(Uint8Array.concat(buffers, size));
+      flushBuffer(Uint8Array.fromList(buffers, size));
       buffers = [];
       size = 0;
     }
@@ -94,57 +94,57 @@ new WritableStream({
 });
 ```
 
-The `concat` method is available on all TypedArray constructors:
+The `fromList` method is available on all TypedArray constructors:
 
 ```js
 // Integer types
-Int8Array.concat([new Int8Array([-1, 127]), new Int8Array([0, -128])]);
+Int8Array.fromList([new Int8Array([-1, 127]), new Int8Array([0, -128])]);
 // → Int8Array [-1, 127, 0, -128]
 
-Uint8Array.concat([new Uint8Array([0, 255]), new Uint8Array([128])]);
+Uint8Array.fromList([new Uint8Array([0, 255]), new Uint8Array([128])]);
 // → Uint8Array [0, 255, 128]
 
-Uint8ClampedArray.concat([new Uint8ClampedArray([0, 255]), new Uint8ClampedArray([128])]);
+Uint8ClampedArray.fromList([new Uint8ClampedArray([0, 255]), new Uint8ClampedArray([128])]);
 // → Uint8ClampedArray [0, 255, 128]
 
-Int16Array.concat([new Int16Array([-1, 32767]), new Int16Array([0])]);
+Int16Array.fromList([new Int16Array([-1, 32767]), new Int16Array([0])]);
 // → Int16Array [-1, 32767, 0]
 
-Uint16Array.concat([new Uint16Array([0, 65535]), new Uint16Array([256])]);
+Uint16Array.fromList([new Uint16Array([0, 65535]), new Uint16Array([256])]);
 // → Uint16Array [0, 65535, 256]
 
-Int32Array.concat([new Int32Array([-1, 2147483647]), new Int32Array([0])]);
+Int32Array.fromList([new Int32Array([-1, 2147483647]), new Int32Array([0])]);
 // → Int32Array [-1, 2147483647, 0]
 
-Uint32Array.concat([new Uint32Array([0, 4294967295]), new Uint32Array([256])]);
+Uint32Array.fromList([new Uint32Array([0, 4294967295]), new Uint32Array([256])]);
 // → Uint32Array [0, 4294967295, 256]
 
 // BigInt types
-BigInt64Array.concat([new BigInt64Array([0n, -1n]), new BigInt64Array([9007199254740991n])]);
+BigInt64Array.fromList([new BigInt64Array([0n, -1n]), new BigInt64Array([9007199254740991n])]);
 // → BigInt64Array [0n, -1n, 9007199254740991n]
 
-BigUint64Array.concat([new BigUint64Array([0n, 1n]), new BigUint64Array([18446744073709551615n])]);
+BigUint64Array.fromList([new BigUint64Array([0n, 1n]), new BigUint64Array([18446744073709551615n])]);
 // → BigUint64Array [0n, 1n, 18446744073709551615n]
 
 // Floating-point types
-Float16Array.concat([new Float16Array([1.5, -0]), new Float16Array([Infinity, NaN])]);
+Float16Array.fromList([new Float16Array([1.5, -0]), new Float16Array([Infinity, NaN])]);
 // → Float16Array [1.5, -0, Infinity, NaN]
 
-Float32Array.concat([new Float32Array([1.5, -0]), new Float32Array([Infinity, NaN])]);
+Float32Array.fromList([new Float32Array([1.5, -0]), new Float32Array([Infinity, NaN])]);
 // → Float32Array [1.5, -0, Infinity, NaN]
 
-Float64Array.concat([new Float64Array([1.5, -0]), new Float64Array([Infinity, NaN])]);
+Float64Array.fromList([new Float64Array([1.5, -0]), new Float64Array([Infinity, NaN])]);
 // → Float64Array [1.5, -0, Infinity, NaN]
 ```
 
-### `ArrayBuffer.concat(items [, options])`
+### `ArrayBuffer.fromList(items [, options])`
 
-Concatenates the byte contents of multiple ArrayBuffers, SharedArrayBuffers, TypedArrays, or DataViews into a new ArrayBuffer.
+Creates a new ArrayBuffer by concatenating the byte contents of multiple ArrayBuffers, SharedArrayBuffers, TypedArrays, or DataViews.
 
 ```js
 const ab1 = new ArrayBuffer(4);
 const ab2 = new ArrayBuffer(4);
-const ab3 = ArrayBuffer.concat([ab1, ab2]);
+const ab3 = ArrayBuffer.fromList([ab1, ab2]);
 // ab3.byteLength === 8
 ```
 
@@ -163,34 +163,34 @@ A `TypeError` is thrown for detached buffers or out-of-bounds DataViews. A `Rang
 const ab = new ArrayBuffer(4);
 const u8 = new Uint8Array([1, 2, 3, 4]);
 const dv = new DataView(new ArrayBuffer(2));
-const result = ArrayBuffer.concat([ab, u8, dv]);
+const result = ArrayBuffer.fromList([ab, u8, dv]);
 // result.byteLength === 10
 
 // Truncate to 6 bytes
-const truncated = ArrayBuffer.concat([ab, u8, dv], { length: 6 });
+const truncated = ArrayBuffer.fromList([ab, u8, dv], { length: 6 });
 
 // Zero-fill to 16 bytes
-const padded = ArrayBuffer.concat([ab, u8], { length: 16 });
+const padded = ArrayBuffer.fromList([ab, u8], { length: 16 });
 
 // Create a resizable result with room to grow
-const resizable = ArrayBuffer.concat([ab, u8], { resizable: true, length: 32 });
+const resizable = ArrayBuffer.fromList([ab, u8], { resizable: true, length: 32 });
 // resizable.byteLength === 8 (actual data)
 // resizable.maxByteLength === 32 (can grow up to 32)
 
 // Create an immutable result (requires Immutable ArrayBuffer proposal)
-const immutable = ArrayBuffer.concat([ab, u8], { immutable: true });
+const immutable = ArrayBuffer.fromList([ab, u8], { immutable: true });
 // immutable.byteLength === 8
 // immutable.immutable === true
 ```
 
-### `SharedArrayBuffer.concat(items [, options])`
+### `SharedArrayBuffer.fromList(items [, options])`
 
-Concatenates the byte contents of multiple ArrayBuffers, SharedArrayBuffers, TypedArrays, or DataViews into a new SharedArrayBuffer.
+Creates a new SharedArrayBuffer by concatenating the byte contents of multiple ArrayBuffers, SharedArrayBuffers, TypedArrays, or DataViews.
 
 ```js
 const sab1 = new SharedArrayBuffer(4);
 const sab2 = new SharedArrayBuffer(4);
-const sab3 = SharedArrayBuffer.concat([sab1, sab2]);
+const sab3 = SharedArrayBuffer.fromList([sab1, sab2]);
 // sab3.byteLength === 8
 ```
 
@@ -208,11 +208,11 @@ A `TypeError` is thrown for detached buffers or out-of-bounds DataViews. A `Rang
 const sab = new SharedArrayBuffer(4);
 const u8 = new Uint8Array([1, 2, 3, 4]);
 const dv = new DataView(new ArrayBuffer(2));
-const result = SharedArrayBuffer.concat([sab, u8, dv]);
+const result = SharedArrayBuffer.fromList([sab, u8, dv]);
 // result.byteLength === 10
 
 // Create a growable result with room to grow
-const growable = SharedArrayBuffer.concat([sab, u8], { growable: true, length: 32 });
+const growable = SharedArrayBuffer.fromList([sab, u8], { growable: true, length: 32 });
 // growable.byteLength === 8 (actual data)
 // growable.maxByteLength === 32 (can grow up to 32)
 ```
@@ -223,8 +223,8 @@ Per the current definition of `TypedArray.prototype.set` in the language specifi
 
 ### Why three methods?
 
-`%TypedArray%.concat` operates at the TypedArray level — it is element-oriented, requires same-type inputs, and returns a TypedArray. This is the right level of abstraction when working with typed data (e.g., concatenating `Uint8Array` chunks in a stream).
+`%TypedArray%.fromList` operates at the TypedArray level — it is element-oriented, requires same-type inputs, and returns a TypedArray. This is the right level of abstraction when working with typed data (e.g., concatenating `Uint8Array` chunks in a stream).
 
-`ArrayBuffer.concat` and `SharedArrayBuffer.concat` operate at the buffer level — they are byte-oriented, accept heterogeneous inputs (ArrayBuffer/SharedArrayBuffer, TypedArray, DataView), and return the appropriate buffer type. This is the right level of abstraction for controlling buffer properties like resizability/growability and immutability, which are concerns of the buffer, not the TypedArray.
+`ArrayBuffer.fromList` and `SharedArrayBuffer.fromList` operate at the buffer level — they are byte-oriented, accept heterogeneous inputs (ArrayBuffer/SharedArrayBuffer, TypedArray, DataView), and return the appropriate buffer type. This is the right level of abstraction for controlling buffer properties like resizability/growability and immutability, which are concerns of the buffer, not the TypedArray.
 
-`ArrayBuffer.concat` and `SharedArrayBuffer.concat` are separate methods because the return type differs and the available options differ (`immutable` is only available for ArrayBuffer, `growable` is only available for SharedArrayBuffer). This mirrors the existing separation between the `ArrayBuffer` and `SharedArrayBuffer` constructors in the language.
+`ArrayBuffer.fromList` and `SharedArrayBuffer.fromList` are separate methods because the return type differs and the available options differ (`immutable` is only available for ArrayBuffer, `growable` is only available for SharedArrayBuffer). This mirrors the existing separation between the `ArrayBuffer` and `SharedArrayBuffer` constructors in the language.

--- a/TEST_CASES.md
+++ b/TEST_CASES.md
@@ -1,5 +1,9 @@
 # Comprehensive Test Cases
 
+**Spec version**: `060d39f`
+**Generated**: 2026-03-07
+**Total assertions**: ~350
+
 Test cases for `%TypedArray%.concat`, `ArrayBuffer.concat`, and `SharedArrayBuffer.concat`.
 
 ### Identifier Convention
@@ -23,11 +27,11 @@ Where a test case is preceded by a "For each ..." qualifier (e.g. "For each Type
 - [ ] [1.1.7] `%TypedArray%.concat.call(Symbol(), [])` → TypeError
 - [ ] [1.1.8] `%TypedArray%.concat.call(() => {}, [])` → TypeError (arrow function is callable but IsConstructor is false)
 
-### 1.2 Constructor without `[[TypedArrayName]]`
+### 1.2 Constructor not in Table 70
 
-- [ ] [1.2.1] `%TypedArray%.concat.call(Array, [])` → TypeError (Array is a constructor but has no `[[TypedArrayName]]`)
+- [ ] [1.2.1] `%TypedArray%.concat.call(Array, [])` → TypeError (Array is a constructor but does not appear in Table 70)
 - [ ] [1.2.2] `%TypedArray%.concat.call(Object, [])` → TypeError
-- [ ] [1.2.3] `%TypedArray%.concat.call(function(){}, [])` → TypeError (custom constructor, no `[[TypedArrayName]]`)
+- [ ] [1.2.3] `%TypedArray%.concat.call(function(){}, [])` → TypeError (custom constructor, not in Table 70)
 
 ### 1.3 Valid TypedArray constructors
 
@@ -46,6 +50,7 @@ For each TypedArray constructor (`Int8Array`, `Uint8Array`, `Uint8ClampedArray`,
 - [ ] [2.1.3] `Uint8Array.concat(42)` → TypeError
 - [ ] [2.1.4] `Uint8Array.concat({})` → TypeError (plain object, no `Symbol.iterator`)
 - [ ] [2.1.5] `Uint8Array.concat('hello')` → TypeError (string is iterable but items should be TypedArrays; the string chars will fail `ValidateTypedArray`)
+- [ ] [2.1.6] `Uint8Array.concat({ [Symbol.iterator]: null })` → TypeError (`GetMethod` returns *undefined* when property is *null*)
 
 ### 2.2 Items iterable throws during iteration
 
@@ -272,6 +277,7 @@ For each BigInt type (`BigInt64Array`, `BigUint64Array`):
 - [ ] [8.1.2] `ArrayBuffer.concat(null)` → TypeError
 - [ ] [8.1.3] `ArrayBuffer.concat(42)` → TypeError
 - [ ] [8.1.4] `ArrayBuffer.concat({})` → TypeError
+- [ ] [8.1.5] `ArrayBuffer.concat({ [Symbol.iterator]: null })` → TypeError (`GetMethod` returns *undefined* when property is *null*)
 
 ### 8.2 Items iterable throws during iteration
 
@@ -361,7 +367,7 @@ For each BigInt type (`BigInt64Array`, `BigUint64Array`):
 - [ ] [9.2.1] `ArrayBuffer.concat([], 42)` → TypeError from `GetOptionsObject`
 - [ ] [9.2.2] `ArrayBuffer.concat([], 'string')` → TypeError
 - [ ] [9.2.3] `ArrayBuffer.concat([], true)` → TypeError
-- [ ] [9.2.4] `ArrayBuffer.concat([], null)` → works (null is treated as no options by `GetOptionsObject` — actually this may vary; verify behavior)
+- [ ] [9.2.4] `ArrayBuffer.concat([], null)` → TypeError (*null* is not *undefined* and not an Object)
 
 ### 9.3 Length option validation
 
@@ -679,50 +685,41 @@ Covered in §10. Included here as a cross-reference.
   try { %TypedArray%.concat.call(42, items); } catch(e) {}
   iteratorCalled // → false
   ```
-- [ ] [16.1.2] Items iteration occurs before length validation:
+- [ ] [16.1.2] Items iteration (step 6) occurs before length validation (step 8):
   ```js
-  // Invalid length, but items are iterated first
   let iteratorCalled = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
   try { Uint8Array.concat(items, NaN); } catch(e) {}
-  iteratorCalled // → true
+  iteratorCalled // → true (items iterated before length is checked)
   ```
 
-  Wait — actually, looking at the spec, items are iterated (step 4) _before_ length is validated (step 6). Let me re-examine...
-
-  Actually no: step 4 iterates items, step 5-7 validates length. So items iteration happens first, then length validation. But the items in the list are _validated_ (step 9) after length validation. So:
-
-- [ ] [16.1.3] Items are collected via iteration before length validation, but individual items are validated (via `ValidateTypedArray`) _after_ length validation:
+- [ ] [16.1.3] Length validation (step 8) occurs before individual item validation (step 10). Items are collected first, then length is checked, then each item is validated:
   ```js
-  // Invalid length AND invalid item — length error wins because length is checked first (step 6)
-  // Wait, step 4 iterates, steps 5-7 validate length, steps 8-11 validate items
-  // So: iterate items first, then validate length, then validate each item
+  // 'bad' fails ValidateIntegralNumber at step 8 before items are validated at step 10
   Uint8Array.concat([42], 'bad') // → TypeError from length validation ('bad' is not a Number)
   ```
 
-- [ ] [16.1.4] Length validation occurs before item type checking:
+- [ ] [16.1.4] Length range check occurs before item type checking:
   ```js
   Uint8Array.concat([new Int16Array([1])], -1) // → RangeError (from length, not TypeError from type mismatch)
   ```
 
 ### 16.2 `ArrayBuffer.concat` evaluation order
 
-- [ ] [16.2.1] Items iteration occurs before options processing:
+- [ ] [16.2.1] Items iteration (steps 1���3) occurs before options processing (step 4+):
   ```js
-  // Items are iterated at step 1, options are read starting at step 2
   let iteratorCalled = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
-  try { ArrayBuffer.concat(items, 42); } catch(e) {} // options error
-  iteratorCalled // → true
+  try { ArrayBuffer.concat(items, 42); } catch(e) {} // options type check error at step 4
+  iteratorCalled // → true (items iterated at step 3, before options checked at step 4)
   ```
-- [ ] [16.2.2] Options processing (length, resizable, immutable) occurs before item validation:
+- [ ] [16.2.2] Options processing (steps 4–10) occurs before item validation (step 11, `GetConcatenationSources`):
   ```js
-  // Invalid options AND invalid items — options error wins
   const detached = new ArrayBuffer(4);
   detached.transfer();
-  ArrayBuffer.concat([detached], { length: 'bad' }) // → TypeError from length validation
+  ArrayBuffer.concat([detached], { length: 'bad' }) // → TypeError from length validation (step 8)
   ```
-- [ ] [16.2.3] `resizable`/`immutable` mutual exclusion check occurs before item validation:
+- [ ] [16.2.3] `resizable`/`immutable` mutual exclusion check (step 10) occurs before item validation (step 11):
   ```js
   const detached = new ArrayBuffer(4);
   detached.transfer();
@@ -731,18 +728,18 @@ Covered in §10. Included here as a cross-reference.
 
 ### 16.3 `SharedArrayBuffer.concat` evaluation order
 
-- [ ] [16.3.1] Items iteration occurs before options processing:
+- [ ] [16.3.1] Items iteration (steps 1–3) occurs before options processing (step 4+):
   ```js
   let iteratorCalled = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
-  try { SharedArrayBuffer.concat(items, 42); } catch(e) {} // options error
-  iteratorCalled // → true
+  try { SharedArrayBuffer.concat(items, 42); } catch(e) {} // options type check error at step 4
+  iteratorCalled // → true (items iterated at step 3, before options checked at step 4)
   ```
-- [ ] [16.3.2] Options processing (length, growable) occurs before item validation:
+- [ ] [16.3.2] Options processing (steps 4–9) occurs before item validation (step 10, `GetConcatenationSources`):
   ```js
   const detached = new ArrayBuffer(4);
   detached.transfer();
-  SharedArrayBuffer.concat([detached], { length: 'bad' }) // → TypeError from length validation
+  SharedArrayBuffer.concat([detached], { length: 'bad' }) // → TypeError from length validation (step 7)
   ```
 
 ### 16.4 Items iterator with side effects
@@ -1474,13 +1471,12 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
 
 ### 25.6 Subclass shenanigans
 
-- [ ] [25.6.1] Calling `concat` on a subclass constructor:
+- [ ] [25.6.1] Calling `concat` on a subclass constructor → TypeError (subclass does not appear in Table 70):
   ```js
   class MyUint8 extends Uint8Array {}
-  // MyUint8 has [[TypedArrayName]] === "Uint8Array" (inherited)
-  // But MyUint8 is a valid constructor with the slot
-  // Behavior depends on whether subclass constructors carry [[TypedArrayName]]
-  // This is worth testing to understand the actual behavior
+  MyUint8.concat([new Uint8Array([1, 2])]) // → TypeError
+  // MyUint8 is a constructor but step 2 checks if `this` appears in the
+  // Constructor column of Table 70. Only intrinsic constructors are listed.
   ```
 - [ ] [25.6.2] Item is a subclass instance:
   ```js
@@ -2010,7 +2006,7 @@ Note: Depends on the [Immutable ArrayBuffer proposal](https://github.com/tc39/pr
 
 ### 30.1 `ArrayBuffer.concat` options access order
 
-The spec reads options properties in order: `length` (step 3), `resizable` (step 6), `immutable` (step 7). Observable via getters.
+The spec reads options properties in order: `length` (step 5a), `resizable` (step 5b), `immutable` (step 5c). Observable via getters.
 
 - [ ] [30.1.1] Options property access order is `length`, then `resizable`, then `immutable`:
   ```js
@@ -2048,7 +2044,7 @@ The spec reads options properties in order: `length` (step 3), `resizable` (step
 
 ### 30.2 `SharedArrayBuffer.concat` options access order
 
-The spec reads options properties in order: `length` (step 3), `growable` (step 6). Observable via getters.
+The spec reads options properties in order: `length` (step 5a), `growable` (step 5b). Observable via getters.
 
 - [ ] [30.2.1] Options property access order is `length`, then `growable`:
   ```js
@@ -2109,6 +2105,7 @@ The spec reads options properties in order: `length` (step 3), `growable` (step 
 - [ ] [32.1.2] `SharedArrayBuffer.concat(null)` → TypeError
 - [ ] [32.1.3] `SharedArrayBuffer.concat(42)` → TypeError
 - [ ] [32.1.4] `SharedArrayBuffer.concat({})` → TypeError
+- [ ] [32.1.5] `SharedArrayBuffer.concat({ [Symbol.iterator]: null })` → TypeError (`GetMethod` returns *undefined* when property is *null*)
 
 ### 32.2 Items iterable throws during iteration
 
@@ -2161,6 +2158,7 @@ The spec reads options properties in order: `length` (step 3), `growable` (step 
 - [ ] [33.2.1] `SharedArrayBuffer.concat([], 42)` → TypeError from `GetOptionsObject`
 - [ ] [33.2.2] `SharedArrayBuffer.concat([], 'string')` → TypeError
 - [ ] [33.2.3] `SharedArrayBuffer.concat([], true)` → TypeError
+- [ ] [33.2.4] `SharedArrayBuffer.concat([], null)` → TypeError (*null* is not *undefined* and not an Object)
 
 ### 33.3 Length option validation
 

--- a/TEST_CASES.md
+++ b/TEST_CASES.md
@@ -4,7 +4,7 @@
 **Generated**: 2026-03-07
 **Total assertions**: ~350
 
-Test cases for `%TypedArray%.concat`, `ArrayBuffer.concat`, and `SharedArrayBuffer.concat`.
+Test cases for `%TypedArray%.fromList`, `ArrayBuffer.fromList`, and `SharedArrayBuffer.fromList`.
 
 ### Identifier Convention
 
@@ -14,43 +14,43 @@ Where a test case is preceded by a "For each ..." qualifier (e.g. "For each Type
 
 ---
 
-## 1. `%TypedArray%.concat` — Receiver Validation
+## 1. `%TypedArray%.fromList` — Receiver Validation
 
 ### 1.1 Invalid `this` value (not a constructor)
 
-- [ ] [1.1.1] `%TypedArray%.concat.call(undefined, [])` → TypeError
-- [ ] [1.1.2] `%TypedArray%.concat.call(null, [])` → TypeError
-- [ ] [1.1.3] `%TypedArray%.concat.call({}, [])` → TypeError
-- [ ] [1.1.4] `%TypedArray%.concat.call(42, [])` → TypeError
-- [ ] [1.1.5] `%TypedArray%.concat.call('string', [])` → TypeError
-- [ ] [1.1.6] `%TypedArray%.concat.call(true, [])` → TypeError
-- [ ] [1.1.7] `%TypedArray%.concat.call(Symbol(), [])` → TypeError
-- [ ] [1.1.8] `%TypedArray%.concat.call(() => {}, [])` → TypeError (arrow function is callable but IsConstructor is false)
+- [ ] [1.1.1] `%TypedArray%.fromList.call(undefined, [])` → TypeError
+- [ ] [1.1.2] `%TypedArray%.fromList.call(null, [])` → TypeError
+- [ ] [1.1.3] `%TypedArray%.fromList.call({}, [])` → TypeError
+- [ ] [1.1.4] `%TypedArray%.fromList.call(42, [])` → TypeError
+- [ ] [1.1.5] `%TypedArray%.fromList.call('string', [])` → TypeError
+- [ ] [1.1.6] `%TypedArray%.fromList.call(true, [])` → TypeError
+- [ ] [1.1.7] `%TypedArray%.fromList.call(Symbol(), [])` → TypeError
+- [ ] [1.1.8] `%TypedArray%.fromList.call(() => {}, [])` → TypeError (arrow function is callable but IsConstructor is false)
 
 ### 1.2 Constructor not in Table 70
 
-- [ ] [1.2.1] `%TypedArray%.concat.call(Array, [])` → TypeError (Array is a constructor but does not appear in Table 70)
-- [ ] [1.2.2] `%TypedArray%.concat.call(Object, [])` → TypeError
-- [ ] [1.2.3] `%TypedArray%.concat.call(function(){}, [])` → TypeError (custom constructor, not in Table 70)
+- [ ] [1.2.1] `%TypedArray%.fromList.call(Array, [])` → TypeError (Array is a constructor but does not appear in Table 70)
+- [ ] [1.2.2] `%TypedArray%.fromList.call(Object, [])` → TypeError
+- [ ] [1.2.3] `%TypedArray%.fromList.call(function(){}, [])` → TypeError (custom constructor, not in Table 70)
 
 ### 1.3 Valid TypedArray constructors
 
 For each TypedArray constructor (`Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float16Array`, `Float32Array`, `Float64Array`, `BigInt64Array`, `BigUint64Array`):
 
-- [ ] [1.3.1] `<Constructor>.concat([])` does not throw (valid receiver, empty items)
+- [ ] [1.3.1] `<Constructor>.fromList([])` does not throw (valid receiver, empty items)
 
 ---
 
-## 2. `%TypedArray%.concat` — Items Validation
+## 2. `%TypedArray%.fromList` — Items Validation
 
 ### 2.1 Items is not iterable
 
-- [ ] [2.1.1] `Uint8Array.concat(undefined)` → TypeError
-- [ ] [2.1.2] `Uint8Array.concat(null)` → TypeError
-- [ ] [2.1.3] `Uint8Array.concat(42)` → TypeError
-- [ ] [2.1.4] `Uint8Array.concat({})` → TypeError (plain object, no `Symbol.iterator`)
-- [ ] [2.1.5] `Uint8Array.concat('hello')` → TypeError (string is iterable but items should be TypedArrays; the string chars will fail `ValidateTypedArray`)
-- [ ] [2.1.6] `Uint8Array.concat({ [Symbol.iterator]: null })` → TypeError (`GetMethod` returns *undefined* when property is *null*)
+- [ ] [2.1.1] `Uint8Array.fromList(undefined)` → TypeError
+- [ ] [2.1.2] `Uint8Array.fromList(null)` → TypeError
+- [ ] [2.1.3] `Uint8Array.fromList(42)` → TypeError
+- [ ] [2.1.4] `Uint8Array.fromList({})` → TypeError (plain object, no `Symbol.iterator`)
+- [ ] [2.1.5] `Uint8Array.fromList('hello')` → TypeError (string is iterable but items should be TypedArrays; the string chars will fail `ValidateTypedArray`)
+- [ ] [2.1.6] `Uint8Array.fromList({ [Symbol.iterator]: null })` → TypeError (`GetMethod` returns *undefined* when property is *null*)
 
 ### 2.2 Items iterable throws during iteration
 
@@ -59,13 +59,13 @@ For each TypedArray constructor (`Int8Array`, `Uint8Array`, `Uint8ClampedArray`,
 
 ### 2.3 Item is not a TypedArray (`ValidateTypedArray` fails)
 
-- [ ] [2.3.1] `Uint8Array.concat([new ArrayBuffer(4)])` → TypeError
-- [ ] [2.3.2] `Uint8Array.concat([new DataView(new ArrayBuffer(4))])` → TypeError
-- [ ] [2.3.3] `Uint8Array.concat([{}])` → TypeError
-- [ ] [2.3.4] `Uint8Array.concat([42])` → TypeError
-- [ ] [2.3.5] `Uint8Array.concat([null])` → TypeError
-- [ ] [2.3.6] `Uint8Array.concat([undefined])` → TypeError
-- [ ] [2.3.7] `Uint8Array.concat([[1, 2, 3]])` → TypeError (plain Array)
+- [ ] [2.3.1] `Uint8Array.fromList([new ArrayBuffer(4)])` → TypeError
+- [ ] [2.3.2] `Uint8Array.fromList([new DataView(new ArrayBuffer(4))])` → TypeError
+- [ ] [2.3.3] `Uint8Array.fromList([{}])` → TypeError
+- [ ] [2.3.4] `Uint8Array.fromList([42])` → TypeError
+- [ ] [2.3.5] `Uint8Array.fromList([null])` → TypeError
+- [ ] [2.3.6] `Uint8Array.fromList([undefined])` → TypeError
+- [ ] [2.3.7] `Uint8Array.fromList([[1, 2, 3]])` → TypeError (plain Array)
 
 ### 2.4 Item is a TypedArray with a detached buffer
 
@@ -73,94 +73,94 @@ For each TypedArray constructor (`Int8Array`, `Uint8Array`, `Uint8ClampedArray`,
   ```js
   const a = new Uint8Array(4);
   a.buffer.transfer();
-  Uint8Array.concat([a]) // → TypeError
+  Uint8Array.fromList([a]) // → TypeError
   ```
 - [ ] [2.4.2] First item valid, second item detached → TypeError on second item
   ```js
   const a = new Uint8Array([1, 2]);
   const b = new Uint8Array(4);
   b.buffer.transfer();
-  Uint8Array.concat([a, b]) // → TypeError
+  Uint8Array.fromList([a, b]) // → TypeError
   ```
 
 ### 2.5 Item is a different TypedArray type (`[[TypedArrayName]]` mismatch)
 
-- [ ] [2.5.1] `Uint8Array.concat([new Int8Array([1, 2])])` → TypeError
-- [ ] [2.5.2] `Uint8Array.concat([new Uint16Array([1, 2])])` → TypeError
-- [ ] [2.5.3] `Uint8Array.concat([new Float64Array([1, 2])])` → TypeError
-- [ ] [2.5.4] `Uint8Array.concat([new BigInt64Array([1n, 2n])])` → TypeError
-- [ ] [2.5.5] `Uint8Array.concat([new Uint8ClampedArray([1, 2])])` → TypeError (Uint8ClampedArray !== Uint8Array)
-- [ ] [2.5.6] `Int32Array.concat([new Uint32Array([1, 2])])` → TypeError
-- [ ] [2.5.7] `BigInt64Array.concat([new BigUint64Array([1n, 2n])])` → TypeError
-- [ ] [2.5.8] Mixed valid and invalid: `Uint8Array.concat([new Uint8Array([1]), new Int16Array([2])])` → TypeError on second item
+- [ ] [2.5.1] `Uint8Array.fromList([new Int8Array([1, 2])])` → TypeError
+- [ ] [2.5.2] `Uint8Array.fromList([new Uint16Array([1, 2])])` → TypeError
+- [ ] [2.5.3] `Uint8Array.fromList([new Float64Array([1, 2])])` → TypeError
+- [ ] [2.5.4] `Uint8Array.fromList([new BigInt64Array([1n, 2n])])` → TypeError
+- [ ] [2.5.5] `Uint8Array.fromList([new Uint8ClampedArray([1, 2])])` → TypeError (Uint8ClampedArray !== Uint8Array)
+- [ ] [2.5.6] `Int32Array.fromList([new Uint32Array([1, 2])])` → TypeError
+- [ ] [2.5.7] `BigInt64Array.fromList([new BigUint64Array([1n, 2n])])` → TypeError
+- [ ] [2.5.8] Mixed valid and invalid: `Uint8Array.fromList([new Uint8Array([1]), new Int16Array([2])])` → TypeError on second item
 
 ### 2.6 Valid same-type items
 
 For each TypedArray type (`Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float16Array`, `Float32Array`, `Float64Array`):
 
-- [ ] [2.6.1] `<Type>.concat([new <Type>([1, 2]), new <Type>([3, 4])])` → `<Type> [1, 2, 3, 4]`
+- [ ] [2.6.1] `<Type>.fromList([new <Type>([1, 2]), new <Type>([3, 4])])` → `<Type> [1, 2, 3, 4]`
 
 For each BigInt type (`BigInt64Array`, `BigUint64Array`):
 
-- [ ] [2.6.2] `<Type>.concat([new <Type>([1n, 2n]), new <Type>([3n, 4n])])` → `<Type> [1n, 2n, 3n, 4n]`
+- [ ] [2.6.2] `<Type>.fromList([new <Type>([1n, 2n]), new <Type>([3n, 4n])])` → `<Type> [1n, 2n, 3n, 4n]`
 
 ---
 
-## 3. `%TypedArray%.concat` — Length Parameter Validation (`ValidateIntegralNumber`)
+## 3. `%TypedArray%.fromList` — Length Parameter Validation (`ValidateIntegralNumber`)
 
 ### 3.1 Length not provided (defaults to total)
 
-- [ ] [3.1.1] `Uint8Array.concat([new Uint8Array([1, 2]), new Uint8Array([3, 4])])` → `Uint8Array [1, 2, 3, 4]` (length 4)
-- [ ] [3.1.2] `Uint8Array.concat([])` → `Uint8Array []` (length 0)
+- [ ] [3.1.1] `Uint8Array.fromList([new Uint8Array([1, 2]), new Uint8Array([3, 4])])` → `Uint8Array [1, 2, 3, 4]` (length 4)
+- [ ] [3.1.2] `Uint8Array.fromList([])` → `Uint8Array []` (length 0)
 
 ### 3.2 Length is `undefined` (same as not provided)
 
-- [ ] [3.2.1] `Uint8Array.concat([new Uint8Array([1, 2])], undefined)` → `Uint8Array [1, 2]`
+- [ ] [3.2.1] `Uint8Array.fromList([new Uint8Array([1, 2])], undefined)` → `Uint8Array [1, 2]`
 
 ### 3.3 Length is non-Number → TypeError
 
-- [ ] [3.3.1] `Uint8Array.concat([], 'hello')` → TypeError
-- [ ] [3.3.2] `Uint8Array.concat([], {})` → TypeError
-- [ ] [3.3.3] `Uint8Array.concat([], true)` → TypeError
-- [ ] [3.3.4] `Uint8Array.concat([], null)` → TypeError
-- [ ] [3.3.5] `Uint8Array.concat([], Symbol())` → TypeError
-- [ ] [3.3.6] `Uint8Array.concat([], 1n)` → TypeError
+- [ ] [3.3.1] `Uint8Array.fromList([], 'hello')` → TypeError
+- [ ] [3.3.2] `Uint8Array.fromList([], {})` → TypeError
+- [ ] [3.3.3] `Uint8Array.fromList([], true)` → TypeError
+- [ ] [3.3.4] `Uint8Array.fromList([], null)` → TypeError
+- [ ] [3.3.5] `Uint8Array.fromList([], Symbol())` → TypeError
+- [ ] [3.3.6] `Uint8Array.fromList([], 1n)` → TypeError
 
 ### 3.4 Length is NaN → RangeError
 
-- [ ] [3.4.1] `Uint8Array.concat([], NaN)` → RangeError
+- [ ] [3.4.1] `Uint8Array.fromList([], NaN)` → RangeError
 
 ### 3.5 Length is non-integral → RangeError
 
-- [ ] [3.5.1] `Uint8Array.concat([], 1.5)` → RangeError
-- [ ] [3.5.2] `Uint8Array.concat([], 0.1)` → RangeError
-- [ ] [3.5.3] `Uint8Array.concat([], Infinity)` → RangeError
-- [ ] [3.5.4] `Uint8Array.concat([], -Infinity)` → RangeError
+- [ ] [3.5.1] `Uint8Array.fromList([], 1.5)` → RangeError
+- [ ] [3.5.2] `Uint8Array.fromList([], 0.1)` → RangeError
+- [ ] [3.5.3] `Uint8Array.fromList([], Infinity)` → RangeError
+- [ ] [3.5.4] `Uint8Array.fromList([], -Infinity)` → RangeError
 
 ### 3.6 Length is negative → RangeError
 
-- [ ] [3.6.1] `Uint8Array.concat([], -1)` → RangeError
-- [ ] [3.6.2] `Uint8Array.concat([], -100)` → RangeError
+- [ ] [3.6.1] `Uint8Array.fromList([], -1)` → RangeError
+- [ ] [3.6.2] `Uint8Array.fromList([], -100)` → RangeError
 
 ### 3.7 Length exceeds 2^53 - 1 → RangeError
 
-- [ ] [3.7.1] `Uint8Array.concat([], 2 ** 53)` → RangeError
-- [ ] [3.7.2] `Uint8Array.concat([], Number.MAX_SAFE_INTEGER + 1)` → RangeError
+- [ ] [3.7.1] `Uint8Array.fromList([], 2 ** 53)` → RangeError
+- [ ] [3.7.2] `Uint8Array.fromList([], Number.MAX_SAFE_INTEGER + 1)` → RangeError
 
 ### 3.8 Length is -0 (treated as 0)
 
-- [ ] [3.8.1] `Uint8Array.concat([new Uint8Array([1, 2])], -0)` → `Uint8Array []` (ℝ(-0) is 0, truncates to empty)
+- [ ] [3.8.1] `Uint8Array.fromList([new Uint8Array([1, 2])], -0)` → `Uint8Array []` (ℝ(-0) is 0, truncates to empty)
 
 ### 3.9 Valid length values
 
-- [ ] [3.9.1] `Uint8Array.concat([new Uint8Array([1, 2])], 0)` → `Uint8Array []` (truncated to 0)
-- [ ] [3.9.2] `Uint8Array.concat([new Uint8Array([1, 2])], 1)` → `Uint8Array [1]` (truncated to 1)
-- [ ] [3.9.3] `Uint8Array.concat([new Uint8Array([1, 2])], 2)` → `Uint8Array [1, 2]` (exact)
-- [ ] [3.9.4] `Uint8Array.concat([new Uint8Array([1, 2])], 5)` → `Uint8Array [1, 2, 0, 0, 0]` (zero-filled)
+- [ ] [3.9.1] `Uint8Array.fromList([new Uint8Array([1, 2])], 0)` → `Uint8Array []` (truncated to 0)
+- [ ] [3.9.2] `Uint8Array.fromList([new Uint8Array([1, 2])], 1)` → `Uint8Array [1]` (truncated to 1)
+- [ ] [3.9.3] `Uint8Array.fromList([new Uint8Array([1, 2])], 2)` → `Uint8Array [1, 2]` (exact)
+- [ ] [3.9.4] `Uint8Array.fromList([new Uint8Array([1, 2])], 5)` → `Uint8Array [1, 2, 0, 0, 0]` (zero-filled)
 
 ---
 
-## 4. `%TypedArray%.concat` — Overflow Check on `totalLength`
+## 4. `%TypedArray%.fromList` — Overflow Check on `totalLength`
 
 ### 4.1 Total length exceeds 2^53 - 1
 
@@ -171,113 +171,113 @@ Note: In practice, creating TypedArrays large enough to trigger this is implemen
 
 ---
 
-## 5. `%TypedArray%.concat` — Basic Concatenation
+## 5. `%TypedArray%.fromList` — Basic Concatenation
 
 ### 5.1 Two arrays
 
 For each non-BigInt type (`Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float16Array`, `Float32Array`, `Float64Array`):
 
-- [ ] [5.1.1] `<Type>.concat([new <Type>([1, 2, 3]), new <Type>([4, 5, 6])])` → `<Type> [1, 2, 3, 4, 5, 6]`
+- [ ] [5.1.1] `<Type>.fromList([new <Type>([1, 2, 3]), new <Type>([4, 5, 6])])` → `<Type> [1, 2, 3, 4, 5, 6]`
 
 For each BigInt type (`BigInt64Array`, `BigUint64Array`):
 
-- [ ] [5.1.2] `<Type>.concat([new <Type>([1n, 2n, 3n]), new <Type>([4n, 5n, 6n])])` → `<Type> [1n, 2n, 3n, 4n, 5n, 6n]`
+- [ ] [5.1.2] `<Type>.fromList([new <Type>([1n, 2n, 3n]), new <Type>([4n, 5n, 6n])])` → `<Type> [1n, 2n, 3n, 4n, 5n, 6n]`
 
 ### 5.2 Three or more arrays
 
-- [ ] [5.2.1] `Uint8Array.concat([new Uint8Array([1]), new Uint8Array([2]), new Uint8Array([3])])` → `Uint8Array [1, 2, 3]`
-- [ ] [5.2.2] `Uint8Array.concat([new Uint8Array([1, 2]), new Uint8Array([3, 4]), new Uint8Array([5, 6]), new Uint8Array([7, 8])])` → `Uint8Array [1, 2, 3, 4, 5, 6, 7, 8]`
+- [ ] [5.2.1] `Uint8Array.fromList([new Uint8Array([1]), new Uint8Array([2]), new Uint8Array([3])])` → `Uint8Array [1, 2, 3]`
+- [ ] [5.2.2] `Uint8Array.fromList([new Uint8Array([1, 2]), new Uint8Array([3, 4]), new Uint8Array([5, 6]), new Uint8Array([7, 8])])` → `Uint8Array [1, 2, 3, 4, 5, 6, 7, 8]`
 
 ### 5.3 Single array
 
-- [ ] [5.3.1] `Uint8Array.concat([new Uint8Array([1, 2, 3])])` → `Uint8Array [1, 2, 3]` (copy of the input)
+- [ ] [5.3.1] `Uint8Array.fromList([new Uint8Array([1, 2, 3])])` → `Uint8Array [1, 2, 3]` (copy of the input)
 - [ ] [5.3.2] Result is a new TypedArray (not the same object):
   ```js
   const a = new Uint8Array([1, 2, 3]);
-  const b = Uint8Array.concat([a]);
+  const b = Uint8Array.fromList([a]);
   b !== a // → true
   b.buffer !== a.buffer // → true
   ```
 
 ### 5.4 Empty items list
 
-- [ ] [5.4.1] `Uint8Array.concat([])` → `Uint8Array []` (length 0)
+- [ ] [5.4.1] `Uint8Array.fromList([])` → `Uint8Array []` (length 0)
 - [ ] [5.4.2] Result has a fresh ArrayBuffer:
   ```js
-  const result = Uint8Array.concat([]);
+  const result = Uint8Array.fromList([]);
   result.byteLength === 0 // → true
   result.buffer instanceof ArrayBuffer // → true
   ```
 
 ### 5.5 Items containing zero-length TypedArrays
 
-- [ ] [5.5.1] `Uint8Array.concat([new Uint8Array([]), new Uint8Array([1, 2])])` → `Uint8Array [1, 2]`
-- [ ] [5.5.2] `Uint8Array.concat([new Uint8Array([1, 2]), new Uint8Array([])])` → `Uint8Array [1, 2]`
-- [ ] [5.5.3] `Uint8Array.concat([new Uint8Array([]), new Uint8Array([])])` → `Uint8Array []`
-- [ ] [5.5.4] `Uint8Array.concat([new Uint8Array([1]), new Uint8Array([]), new Uint8Array([2])])` → `Uint8Array [1, 2]`
+- [ ] [5.5.1] `Uint8Array.fromList([new Uint8Array([]), new Uint8Array([1, 2])])` → `Uint8Array [1, 2]`
+- [ ] [5.5.2] `Uint8Array.fromList([new Uint8Array([1, 2]), new Uint8Array([])])` → `Uint8Array [1, 2]`
+- [ ] [5.5.3] `Uint8Array.fromList([new Uint8Array([]), new Uint8Array([])])` → `Uint8Array []`
+- [ ] [5.5.4] `Uint8Array.fromList([new Uint8Array([1]), new Uint8Array([]), new Uint8Array([2])])` → `Uint8Array [1, 2]`
 
 ### 5.6 Result TypedArray type matches constructor
 
-- [ ] [5.6.1] `Float64Array.concat([new Float64Array([1.5, 2.5])])` → result is a `Float64Array`, not `Uint8Array`
-- [ ] [5.6.2] `BigInt64Array.concat([new BigInt64Array([1n])])` → result is a `BigInt64Array`
+- [ ] [5.6.1] `Float64Array.fromList([new Float64Array([1.5, 2.5])])` → result is a `Float64Array`, not `Uint8Array`
+- [ ] [5.6.2] `BigInt64Array.fromList([new BigInt64Array([1n])])` → result is a `BigInt64Array`
 
 ---
 
-## 6. `%TypedArray%.concat` — Truncation and Zero-Fill
+## 6. `%TypedArray%.fromList` — Truncation and Zero-Fill
 
 ### 6.1 Truncation (length < totalLength)
 
-- [ ] [6.1.1] `Uint8Array.concat([new Uint8Array([1, 2, 3, 4, 5])], 3)` → `Uint8Array [1, 2, 3]`
-- [ ] [6.1.2] `Uint8Array.concat([new Uint8Array([1, 2]), new Uint8Array([3, 4])], 3)` → `Uint8Array [1, 2, 3]` (truncates mid-second-array)
-- [ ] [6.1.3] `Uint8Array.concat([new Uint8Array([1, 2]), new Uint8Array([3, 4])], 2)` → `Uint8Array [1, 2]` (truncates at boundary)
-- [ ] [6.1.4] `Uint8Array.concat([new Uint8Array([1, 2]), new Uint8Array([3, 4]), new Uint8Array([5, 6])], 1)` → `Uint8Array [1]` (third array entirely skipped)
-- [ ] [6.1.5] `Uint8Array.concat([new Uint8Array([1, 2, 3])], 0)` → `Uint8Array []`
+- [ ] [6.1.1] `Uint8Array.fromList([new Uint8Array([1, 2, 3, 4, 5])], 3)` → `Uint8Array [1, 2, 3]`
+- [ ] [6.1.2] `Uint8Array.fromList([new Uint8Array([1, 2]), new Uint8Array([3, 4])], 3)` → `Uint8Array [1, 2, 3]` (truncates mid-second-array)
+- [ ] [6.1.3] `Uint8Array.fromList([new Uint8Array([1, 2]), new Uint8Array([3, 4])], 2)` → `Uint8Array [1, 2]` (truncates at boundary)
+- [ ] [6.1.4] `Uint8Array.fromList([new Uint8Array([1, 2]), new Uint8Array([3, 4]), new Uint8Array([5, 6])], 1)` → `Uint8Array [1]` (third array entirely skipped)
+- [ ] [6.1.5] `Uint8Array.fromList([new Uint8Array([1, 2, 3])], 0)` → `Uint8Array []`
 
 ### 6.2 Zero-fill (length > totalLength)
 
-- [ ] [6.2.1] `Uint8Array.concat([new Uint8Array([1, 2])], 5)` → `Uint8Array [1, 2, 0, 0, 0]`
-- [ ] [6.2.2] `Uint8Array.concat([], 3)` → `Uint8Array [0, 0, 0]` (no items, all zero-filled)
-- [ ] [6.2.3] `Int32Array.concat([new Int32Array([1])], 4)` → `Int32Array [1, 0, 0, 0]`
-- [ ] [6.2.4] `Float64Array.concat([new Float64Array([1.5])], 3)` → `Float64Array [1.5, 0, 0]`
-- [ ] [6.2.5] `BigInt64Array.concat([new BigInt64Array([1n])], 3)` → `BigInt64Array [1n, 0n, 0n]`
+- [ ] [6.2.1] `Uint8Array.fromList([new Uint8Array([1, 2])], 5)` → `Uint8Array [1, 2, 0, 0, 0]`
+- [ ] [6.2.2] `Uint8Array.fromList([], 3)` → `Uint8Array [0, 0, 0]` (no items, all zero-filled)
+- [ ] [6.2.3] `Int32Array.fromList([new Int32Array([1])], 4)` → `Int32Array [1, 0, 0, 0]`
+- [ ] [6.2.4] `Float64Array.fromList([new Float64Array([1.5])], 3)` → `Float64Array [1.5, 0, 0]`
+- [ ] [6.2.5] `BigInt64Array.fromList([new BigInt64Array([1n])], 3)` → `BigInt64Array [1n, 0n, 0n]`
 
 ### 6.3 Exact length
 
-- [ ] [6.3.1] `Uint8Array.concat([new Uint8Array([1, 2, 3])], 3)` → `Uint8Array [1, 2, 3]` (same as no length)
+- [ ] [6.3.1] `Uint8Array.fromList([new Uint8Array([1, 2, 3])], 3)` → `Uint8Array [1, 2, 3]` (same as no length)
 
 ---
 
-## 7. `%TypedArray%.concat` — Element Value Preservation
+## 7. `%TypedArray%.fromList` — Element Value Preservation
 
 ### 7.1 Boundary values per type
 
-- [ ] [7.1.1] `Int8Array.concat([new Int8Array([-128, 127])])` → `Int8Array [-128, 127]`
-- [ ] [7.1.2] `Uint8Array.concat([new Uint8Array([0, 255])])` → `Uint8Array [0, 255]`
-- [ ] [7.1.3] `Uint8ClampedArray.concat([new Uint8ClampedArray([0, 255])])` → `Uint8ClampedArray [0, 255]`
-- [ ] [7.1.4] `Int16Array.concat([new Int16Array([-32768, 32767])])` → `Int16Array [-32768, 32767]`
-- [ ] [7.1.5] `Uint16Array.concat([new Uint16Array([0, 65535])])` → `Uint16Array [0, 65535]`
-- [ ] [7.1.6] `Int32Array.concat([new Int32Array([-2147483648, 2147483647])])` → `Int32Array [-2147483648, 2147483647]`
-- [ ] [7.1.7] `Uint32Array.concat([new Uint32Array([0, 4294967295])])` → `Uint32Array [0, 4294967295]`
-- [ ] [7.1.8] `BigInt64Array.concat([new BigInt64Array([-9223372036854775808n, 9223372036854775807n])])` → preserves values
-- [ ] [7.1.9] `BigUint64Array.concat([new BigUint64Array([0n, 18446744073709551615n])])` → preserves values
+- [ ] [7.1.1] `Int8Array.fromList([new Int8Array([-128, 127])])` → `Int8Array [-128, 127]`
+- [ ] [7.1.2] `Uint8Array.fromList([new Uint8Array([0, 255])])` → `Uint8Array [0, 255]`
+- [ ] [7.1.3] `Uint8ClampedArray.fromList([new Uint8ClampedArray([0, 255])])` → `Uint8ClampedArray [0, 255]`
+- [ ] [7.1.4] `Int16Array.fromList([new Int16Array([-32768, 32767])])` → `Int16Array [-32768, 32767]`
+- [ ] [7.1.5] `Uint16Array.fromList([new Uint16Array([0, 65535])])` → `Uint16Array [0, 65535]`
+- [ ] [7.1.6] `Int32Array.fromList([new Int32Array([-2147483648, 2147483647])])` → `Int32Array [-2147483648, 2147483647]`
+- [ ] [7.1.7] `Uint32Array.fromList([new Uint32Array([0, 4294967295])])` → `Uint32Array [0, 4294967295]`
+- [ ] [7.1.8] `BigInt64Array.fromList([new BigInt64Array([-9223372036854775808n, 9223372036854775807n])])` → preserves values
+- [ ] [7.1.9] `BigUint64Array.fromList([new BigUint64Array([0n, 18446744073709551615n])])` → preserves values
 
 ### 7.2 Floating-point special values
 
-- [ ] [7.2.1] `Float64Array.concat([new Float64Array([NaN, Infinity, -Infinity, -0, 0])])` → preserves all special values
-- [ ] [7.2.2] `Float32Array.concat([new Float32Array([NaN, Infinity, -Infinity])])` → preserves all special values
-- [ ] [7.2.3] `Float64Array.concat([new Float64Array([NaN]), new Float64Array([Infinity])])` → `Float64Array [NaN, Infinity]`
+- [ ] [7.2.1] `Float64Array.fromList([new Float64Array([NaN, Infinity, -Infinity, -0, 0])])` → preserves all special values
+- [ ] [7.2.2] `Float32Array.fromList([new Float32Array([NaN, Infinity, -Infinity])])` → preserves all special values
+- [ ] [7.2.3] `Float64Array.fromList([new Float64Array([NaN]), new Float64Array([Infinity])])` → `Float64Array [NaN, Infinity]`
 
 ---
 
-## 8. `ArrayBuffer.concat` — Items Validation
+## 8. `ArrayBuffer.fromList` — Items Validation
 
 ### 8.1 Items is not iterable
 
-- [ ] [8.1.1] `ArrayBuffer.concat(undefined)` → TypeError
-- [ ] [8.1.2] `ArrayBuffer.concat(null)` → TypeError
-- [ ] [8.1.3] `ArrayBuffer.concat(42)` → TypeError
-- [ ] [8.1.4] `ArrayBuffer.concat({})` → TypeError
-- [ ] [8.1.5] `ArrayBuffer.concat({ [Symbol.iterator]: null })` → TypeError (`GetMethod` returns *undefined* when property is *null*)
+- [ ] [8.1.1] `ArrayBuffer.fromList(undefined)` → TypeError
+- [ ] [8.1.2] `ArrayBuffer.fromList(null)` → TypeError
+- [ ] [8.1.3] `ArrayBuffer.fromList(42)` → TypeError
+- [ ] [8.1.4] `ArrayBuffer.fromList({})` → TypeError
+- [ ] [8.1.5] `ArrayBuffer.fromList({ [Symbol.iterator]: null })` → TypeError (`GetMethod` returns *undefined* when property is *null*)
 
 ### 8.2 Items iterable throws during iteration
 
@@ -286,20 +286,20 @@ For each BigInt type (`BigInt64Array`, `BigUint64Array`):
 
 ### 8.3 Item is not an ArrayBuffer, TypedArray, or DataView
 
-- [ ] [8.3.1] `ArrayBuffer.concat([42])` → TypeError
-- [ ] [8.3.2] `ArrayBuffer.concat([{}])` → TypeError
-- [ ] [8.3.3] `ArrayBuffer.concat(['string'])` → TypeError
-- [ ] [8.3.4] `ArrayBuffer.concat([null])` → TypeError
-- [ ] [8.3.5] `ArrayBuffer.concat([undefined])` → TypeError
-- [ ] [8.3.6] `ArrayBuffer.concat([[1, 2, 3]])` → TypeError (plain Array)
+- [ ] [8.3.1] `ArrayBuffer.fromList([42])` → TypeError
+- [ ] [8.3.2] `ArrayBuffer.fromList([{}])` → TypeError
+- [ ] [8.3.3] `ArrayBuffer.fromList(['string'])` → TypeError
+- [ ] [8.3.4] `ArrayBuffer.fromList([null])` → TypeError
+- [ ] [8.3.5] `ArrayBuffer.fromList([undefined])` → TypeError
+- [ ] [8.3.6] `ArrayBuffer.fromList([[1, 2, 3]])` → TypeError (plain Array)
 
 ### 8.4 Item is a SharedArrayBuffer (accepted)
 
-- [ ] [8.4.1] `ArrayBuffer.concat([new SharedArrayBuffer(4)])` → works (SharedArrayBuffer is accepted; result is an ArrayBuffer)
+- [ ] [8.4.1] `ArrayBuffer.fromList([new SharedArrayBuffer(4)])` → works (SharedArrayBuffer is accepted; result is an ArrayBuffer)
   ```js
   const sab = new SharedArrayBuffer(4);
   new Uint8Array(sab).set([1, 2, 3, 4]);
-  const result = ArrayBuffer.concat([sab]);
+  const result = ArrayBuffer.fromList([sab]);
   result.byteLength // → 4
   result instanceof ArrayBuffer // → true
   result instanceof SharedArrayBuffer // → false
@@ -311,7 +311,7 @@ For each BigInt type (`BigInt64Array`, `BigUint64Array`):
   new Uint8Array(ab).set([1, 2]);
   const sab = new SharedArrayBuffer(2);
   new Uint8Array(sab).set([3, 4]);
-  const result = ArrayBuffer.concat([ab, sab]);
+  const result = ArrayBuffer.fromList([ab, sab]);
   result.byteLength // → 4
   result instanceof ArrayBuffer // → true
   new Uint8Array(result) // → [1, 2, 3, 4]
@@ -323,7 +323,7 @@ For each BigInt type (`BigInt64Array`, `BigUint64Array`):
   ```js
   const ab = new ArrayBuffer(4);
   ab.transfer();
-  ArrayBuffer.concat([ab]) // → TypeError
+  ArrayBuffer.fromList([ab]) // → TypeError
   ```
 
 ### 8.6 Item is a TypedArray with a detached buffer
@@ -336,7 +336,7 @@ For each BigInt type (`BigInt64Array`, `BigUint64Array`):
 
 ### 8.8 Mixed valid item types
 
-- [ ] [8.8.1] `ArrayBuffer.concat([new ArrayBuffer(2), new Uint8Array([1, 2]), new DataView(new ArrayBuffer(3))])` → ArrayBuffer of byteLength 7
+- [ ] [8.8.1] `ArrayBuffer.fromList([new ArrayBuffer(2), new Uint8Array([1, 2]), new DataView(new ArrayBuffer(3))])` → ArrayBuffer of byteLength 7
 - [ ] [8.8.2] First item valid, second item invalid → TypeError on second item
 - [ ] [8.8.3] Mix of all four input types:
   ```js
@@ -347,7 +347,7 @@ For each BigInt type (`BigInt64Array`, `BigUint64Array`):
   const u8 = new Uint8Array([5, 6]);
   const dv = new DataView(new ArrayBuffer(2));
   new Uint8Array(dv.buffer).set([7, 8]);
-  const result = ArrayBuffer.concat([ab, sab, u8, dv]);
+  const result = ArrayBuffer.fromList([ab, sab, u8, dv]);
   result.byteLength // → 8
   result instanceof ArrayBuffer // → true
   new Uint8Array(result) // → [1, 2, 3, 4, 5, 6, 7, 8]
@@ -355,76 +355,76 @@ For each BigInt type (`BigInt64Array`, `BigUint64Array`):
 
 ---
 
-## 9. `ArrayBuffer.concat` — Options Validation
+## 9. `ArrayBuffer.fromList` — Options Validation
 
 ### 9.1 Options is `undefined` or not provided
 
-- [ ] [9.1.1] `ArrayBuffer.concat([new ArrayBuffer(4)])` → works, no options
-- [ ] [9.1.2] `ArrayBuffer.concat([new ArrayBuffer(4)], undefined)` → works, same as no options
+- [ ] [9.1.1] `ArrayBuffer.fromList([new ArrayBuffer(4)])` → works, no options
+- [ ] [9.1.2] `ArrayBuffer.fromList([new ArrayBuffer(4)], undefined)` → works, same as no options
 
 ### 9.2 Options is not an object
 
-- [ ] [9.2.1] `ArrayBuffer.concat([], 42)` → TypeError from `GetOptionsObject`
-- [ ] [9.2.2] `ArrayBuffer.concat([], 'string')` → TypeError
-- [ ] [9.2.3] `ArrayBuffer.concat([], true)` → TypeError
-- [ ] [9.2.4] `ArrayBuffer.concat([], null)` → TypeError (*null* is not *undefined* and not an Object)
+- [ ] [9.2.1] `ArrayBuffer.fromList([], 42)` → TypeError from `GetOptionsObject`
+- [ ] [9.2.2] `ArrayBuffer.fromList([], 'string')` → TypeError
+- [ ] [9.2.3] `ArrayBuffer.fromList([], true)` → TypeError
+- [ ] [9.2.4] `ArrayBuffer.fromList([], null)` → TypeError (*null* is not *undefined* and not an Object)
 
 ### 9.3 Length option validation
 
 #### 9.3.1 Non-Number length → TypeError
 
-- [ ] [9.3.1.1] `ArrayBuffer.concat([], { length: 'hello' })` → TypeError
-- [ ] [9.3.1.2] `ArrayBuffer.concat([], { length: {} })` → TypeError
-- [ ] [9.3.1.3] `ArrayBuffer.concat([], { length: true })` → TypeError
-- [ ] [9.3.1.4] `ArrayBuffer.concat([], { length: Symbol() })` → TypeError
-- [ ] [9.3.1.5] `ArrayBuffer.concat([], { length: 1n })` → TypeError
+- [ ] [9.3.1.1] `ArrayBuffer.fromList([], { length: 'hello' })` → TypeError
+- [ ] [9.3.1.2] `ArrayBuffer.fromList([], { length: {} })` → TypeError
+- [ ] [9.3.1.3] `ArrayBuffer.fromList([], { length: true })` → TypeError
+- [ ] [9.3.1.4] `ArrayBuffer.fromList([], { length: Symbol() })` → TypeError
+- [ ] [9.3.1.5] `ArrayBuffer.fromList([], { length: 1n })` → TypeError
 
 #### 9.3.2 NaN / non-integral / Infinity → RangeError
 
-- [ ] [9.3.2.1] `ArrayBuffer.concat([], { length: NaN })` → RangeError
-- [ ] [9.3.2.2] `ArrayBuffer.concat([], { length: 1.5 })` → RangeError
-- [ ] [9.3.2.3] `ArrayBuffer.concat([], { length: Infinity })` → RangeError
-- [ ] [9.3.2.4] `ArrayBuffer.concat([], { length: -Infinity })` → RangeError
+- [ ] [9.3.2.1] `ArrayBuffer.fromList([], { length: NaN })` → RangeError
+- [ ] [9.3.2.2] `ArrayBuffer.fromList([], { length: 1.5 })` → RangeError
+- [ ] [9.3.2.3] `ArrayBuffer.fromList([], { length: Infinity })` → RangeError
+- [ ] [9.3.2.4] `ArrayBuffer.fromList([], { length: -Infinity })` → RangeError
 
 #### 9.3.3 Negative length → RangeError
 
-- [ ] [9.3.3.1] `ArrayBuffer.concat([], { length: -1 })` → RangeError
-- [ ] [9.3.3.2] `ArrayBuffer.concat([], { length: -100 })` → RangeError
+- [ ] [9.3.3.1] `ArrayBuffer.fromList([], { length: -1 })` → RangeError
+- [ ] [9.3.3.2] `ArrayBuffer.fromList([], { length: -100 })` → RangeError
 
 #### 9.3.4 Length exceeds 2^53 - 1 → RangeError
 
-- [ ] [9.3.4.1] `ArrayBuffer.concat([], { length: 2 ** 53 })` → RangeError
-- [ ] [9.3.4.2] `ArrayBuffer.concat([], { length: Number.MAX_SAFE_INTEGER + 1 })` → RangeError
+- [ ] [9.3.4.1] `ArrayBuffer.fromList([], { length: 2 ** 53 })` → RangeError
+- [ ] [9.3.4.2] `ArrayBuffer.fromList([], { length: Number.MAX_SAFE_INTEGER + 1 })` → RangeError
 
 #### 9.3.5 Length is -0 (treated as 0)
 
-- [ ] [9.3.5.1] `ArrayBuffer.concat([new ArrayBuffer(4)], { length: -0 })` → ArrayBuffer of byteLength 0
+- [ ] [9.3.5.1] `ArrayBuffer.fromList([new ArrayBuffer(4)], { length: -0 })` → ArrayBuffer of byteLength 0
 
 #### 9.3.6 Length is `undefined` (same as not provided)
 
-- [ ] [9.3.6.1] `ArrayBuffer.concat([new ArrayBuffer(4)], { length: undefined })` → byteLength 4 (defaults to total)
+- [ ] [9.3.6.1] `ArrayBuffer.fromList([new ArrayBuffer(4)], { length: undefined })` → byteLength 4 (defaults to total)
 
 ### 9.4 Resizable and immutable options
 
-- [ ] [9.4.1] `ArrayBuffer.concat([], { resizable: true, immutable: true })` → TypeError (mutually exclusive)
-- [ ] [9.4.2] `ArrayBuffer.concat([], { resizable: true, immutable: false })` → works
-- [ ] [9.4.3] `ArrayBuffer.concat([], { resizable: false, immutable: true })` → works
-- [ ] [9.4.4] `ArrayBuffer.concat([], { resizable: false, immutable: false })` → works (default behavior)
+- [ ] [9.4.1] `ArrayBuffer.fromList([], { resizable: true, immutable: true })` → TypeError (mutually exclusive)
+- [ ] [9.4.2] `ArrayBuffer.fromList([], { resizable: true, immutable: false })` → works
+- [ ] [9.4.3] `ArrayBuffer.fromList([], { resizable: false, immutable: true })` → works
+- [ ] [9.4.4] `ArrayBuffer.fromList([], { resizable: false, immutable: false })` → works (default behavior)
 
 ### 9.5 Resizable and immutable are coerced via `ToBoolean`
 
-- [ ] [9.5.1] `ArrayBuffer.concat([], { resizable: 1 })` → result is resizable (truthy)
-- [ ] [9.5.2] `ArrayBuffer.concat([], { resizable: 0 })` → result is not resizable (falsy)
-- [ ] [9.5.3] `ArrayBuffer.concat([], { resizable: '' })` → result is not resizable (falsy)
-- [ ] [9.5.4] `ArrayBuffer.concat([], { resizable: 'yes' })` → result is resizable (truthy)
-- [ ] [9.5.5] `ArrayBuffer.concat([], { immutable: 1 })` → result is immutable (truthy)
-- [ ] [9.5.6] `ArrayBuffer.concat([], { immutable: 0 })` → result is not immutable (falsy)
-- [ ] [9.5.7] `ArrayBuffer.concat([], { resizable: null })` → result is not resizable (falsy)
-- [ ] [9.5.8] `ArrayBuffer.concat([], { immutable: undefined })` → result is not immutable (falsy)
+- [ ] [9.5.1] `ArrayBuffer.fromList([], { resizable: 1 })` → result is resizable (truthy)
+- [ ] [9.5.2] `ArrayBuffer.fromList([], { resizable: 0 })` → result is not resizable (falsy)
+- [ ] [9.5.3] `ArrayBuffer.fromList([], { resizable: '' })` → result is not resizable (falsy)
+- [ ] [9.5.4] `ArrayBuffer.fromList([], { resizable: 'yes' })` → result is resizable (truthy)
+- [ ] [9.5.5] `ArrayBuffer.fromList([], { immutable: 1 })` → result is immutable (truthy)
+- [ ] [9.5.6] `ArrayBuffer.fromList([], { immutable: 0 })` → result is not immutable (falsy)
+- [ ] [9.5.7] `ArrayBuffer.fromList([], { resizable: null })` → result is not resizable (falsy)
+- [ ] [9.5.8] `ArrayBuffer.fromList([], { immutable: undefined })` → result is not immutable (falsy)
 
 ---
 
-## 10. `ArrayBuffer.concat` — Overflow Check on `totalByteLength`
+## 10. `ArrayBuffer.fromList` — Overflow Check on `totalByteLength`
 
 ### 10.1 Total byte length exceeds 2^53 - 1
 
@@ -436,7 +436,7 @@ Note: As with §4, creating buffers large enough to trigger this may be implemen
 
 ---
 
-## 11. `ArrayBuffer.concat` — Basic Concatenation
+## 11. `ArrayBuffer.fromList` — Basic Concatenation
 
 ### 11.1 ArrayBuffer inputs
 
@@ -446,7 +446,7 @@ Note: As with §4, creating buffers large enough to trigger this may be implemen
   new Uint8Array(ab1).set([1, 2, 3, 4]);
   const ab2 = new ArrayBuffer(4);
   new Uint8Array(ab2).set([5, 6, 7, 8]);
-  const result = ArrayBuffer.concat([ab1, ab2]);
+  const result = ArrayBuffer.fromList([ab1, ab2]);
   // result.byteLength === 8
   // new Uint8Array(result) → [1, 2, 3, 4, 5, 6, 7, 8]
   ```
@@ -458,7 +458,7 @@ Note: As with §4, creating buffers large enough to trigger this may be implemen
 - [ ] [11.2.1] Full-buffer TypedArray:
   ```js
   const u8 = new Uint8Array([1, 2, 3, 4]);
-  const result = ArrayBuffer.concat([u8]);
+  const result = ArrayBuffer.fromList([u8]);
   // result.byteLength === 4
   ```
 - [ ] [11.2.2] TypedArray with byte offset:
@@ -466,21 +466,21 @@ Note: As with §4, creating buffers large enough to trigger this may be implemen
   const ab = new ArrayBuffer(8);
   new Uint8Array(ab).set([1, 2, 3, 4, 5, 6, 7, 8]);
   const view = new Uint8Array(ab, 2, 3); // views bytes [3, 4, 5]
-  const result = ArrayBuffer.concat([view]);
+  const result = ArrayBuffer.fromList([view]);
   // result.byteLength === 3
   // new Uint8Array(result) → [3, 4, 5]
   ```
 - [ ] [11.2.3] Multi-byte element TypedArray (only viewed portion bytes):
   ```js
   const i32 = new Int32Array([1, 2]); // 8 bytes
-  const result = ArrayBuffer.concat([i32]);
+  const result = ArrayBuffer.fromList([i32]);
   // result.byteLength === 8
   ```
 - [ ] [11.2.4] TypedArray with non-zero offset and multi-byte elements:
   ```js
   const ab = new ArrayBuffer(16);
   const view = new Int32Array(ab, 4, 2); // 8 bytes starting at offset 4
-  const result = ArrayBuffer.concat([view]);
+  const result = ArrayBuffer.fromList([view]);
   // result.byteLength === 8
   ```
 
@@ -491,7 +491,7 @@ Note: As with §4, creating buffers large enough to trigger this may be implemen
   const ab = new ArrayBuffer(4);
   new Uint8Array(ab).set([1, 2, 3, 4]);
   const dv = new DataView(ab);
-  const result = ArrayBuffer.concat([dv]);
+  const result = ArrayBuffer.fromList([dv]);
   // result.byteLength === 4
   ```
 - [ ] [11.3.2] DataView with byte offset and length:
@@ -499,7 +499,7 @@ Note: As with §4, creating buffers large enough to trigger this may be implemen
   const ab = new ArrayBuffer(8);
   new Uint8Array(ab).set([1, 2, 3, 4, 5, 6, 7, 8]);
   const dv = new DataView(ab, 2, 3); // views bytes [3, 4, 5]
-  const result = ArrayBuffer.concat([dv]);
+  const result = ArrayBuffer.fromList([dv]);
   // result.byteLength === 3
   // new Uint8Array(result) → [3, 4, 5]
   ```
@@ -513,94 +513,94 @@ Note: As with §4, creating buffers large enough to trigger this may be implemen
   const u8 = new Uint8Array([3, 4]);
   const dv = new DataView(new ArrayBuffer(2));
   new Uint8Array(dv.buffer).set([5, 6]);
-  const result = ArrayBuffer.concat([ab, u8, dv]);
+  const result = ArrayBuffer.fromList([ab, u8, dv]);
   // result.byteLength === 6
   // new Uint8Array(result) → [1, 2, 3, 4, 5, 6]
   ```
 
 ### 11.5 Empty inputs
 
-- [ ] [11.5.1] `ArrayBuffer.concat([])` → ArrayBuffer of byteLength 0
-- [ ] [11.5.2] `ArrayBuffer.concat([new ArrayBuffer(0)])` → ArrayBuffer of byteLength 0
-- [ ] [11.5.3] `ArrayBuffer.concat([new ArrayBuffer(0), new ArrayBuffer(0)])` → ArrayBuffer of byteLength 0
-- [ ] [11.5.4] `ArrayBuffer.concat([new ArrayBuffer(0), new Uint8Array([1, 2])])` → byteLength 2
+- [ ] [11.5.1] `ArrayBuffer.fromList([])` → ArrayBuffer of byteLength 0
+- [ ] [11.5.2] `ArrayBuffer.fromList([new ArrayBuffer(0)])` → ArrayBuffer of byteLength 0
+- [ ] [11.5.3] `ArrayBuffer.fromList([new ArrayBuffer(0), new ArrayBuffer(0)])` → ArrayBuffer of byteLength 0
+- [ ] [11.5.4] `ArrayBuffer.fromList([new ArrayBuffer(0), new Uint8Array([1, 2])])` → byteLength 2
 
 ### 11.6 Result is always a new ArrayBuffer
 
 - [ ] [11.6.1] Result is not the same object as any input:
   ```js
   const ab = new ArrayBuffer(4);
-  const result = ArrayBuffer.concat([ab]);
+  const result = ArrayBuffer.fromList([ab]);
   result !== ab // → true
   ```
 
 ---
 
-## 12. `ArrayBuffer.concat` — Truncation and Zero-Fill
+## 12. `ArrayBuffer.fromList` — Truncation and Zero-Fill
 
 ### 12.1 Truncation (length < totalByteLength)
 
-- [ ] [12.1.1] `ArrayBuffer.concat([new ArrayBuffer(8)], { length: 4 })` → byteLength 4
+- [ ] [12.1.1] `ArrayBuffer.fromList([new ArrayBuffer(8)], { length: 4 })` → byteLength 4
 - [ ] [12.1.2] Truncation mid-second-item:
   ```js
   const ab1 = new ArrayBuffer(4);
   new Uint8Array(ab1).set([1, 2, 3, 4]);
   const ab2 = new ArrayBuffer(4);
   new Uint8Array(ab2).set([5, 6, 7, 8]);
-  const result = ArrayBuffer.concat([ab1, ab2], { length: 6 });
+  const result = ArrayBuffer.fromList([ab1, ab2], { length: 6 });
   // new Uint8Array(result) → [1, 2, 3, 4, 5, 6]
   ```
-- [ ] [12.1.3] Truncation to 0: `ArrayBuffer.concat([new ArrayBuffer(4)], { length: 0 })` → byteLength 0
+- [ ] [12.1.3] Truncation to 0: `ArrayBuffer.fromList([new ArrayBuffer(4)], { length: 0 })` → byteLength 0
 
 ### 12.2 Zero-fill (length > totalByteLength)
 
-- [ ] [12.2.1] `ArrayBuffer.concat([new ArrayBuffer(4)], { length: 8 })` → byteLength 8, last 4 bytes are 0
-- [ ] [12.2.2] `ArrayBuffer.concat([], { length: 4 })` → byteLength 4, all bytes 0
+- [ ] [12.2.1] `ArrayBuffer.fromList([new ArrayBuffer(4)], { length: 8 })` → byteLength 8, last 4 bytes are 0
+- [ ] [12.2.2] `ArrayBuffer.fromList([], { length: 4 })` → byteLength 4, all bytes 0
 - [ ] [12.2.3] Verify zero-fill bytes are actually 0:
   ```js
   const ab = new ArrayBuffer(2);
   new Uint8Array(ab).set([0xFF, 0xFF]);
-  const result = ArrayBuffer.concat([ab], { length: 4 });
+  const result = ArrayBuffer.fromList([ab], { length: 4 });
   const u8 = new Uint8Array(result);
   // u8[0] === 0xFF, u8[1] === 0xFF, u8[2] === 0, u8[3] === 0
   ```
 
 ### 12.3 Exact length
 
-- [ ] [12.3.1] `ArrayBuffer.concat([new ArrayBuffer(4)], { length: 4 })` → byteLength 4 (same as no length)
+- [ ] [12.3.1] `ArrayBuffer.fromList([new ArrayBuffer(4)], { length: 4 })` → byteLength 4 (same as no length)
 
 ---
 
-## 13. `ArrayBuffer.concat` — Resizable Option
+## 13. `ArrayBuffer.fromList` — Resizable Option
 
 ### 13.1 Basic resizable result
 
 - [ ] [13.1.1] Resizable with explicit length:
   ```js
-  const result = ArrayBuffer.concat([new ArrayBuffer(4)], { resizable: true, length: 16 });
+  const result = ArrayBuffer.fromList([new ArrayBuffer(4)], { resizable: true, length: 16 });
   result.resizable // → true
   result.byteLength // → 4 (actual data)
   result.maxByteLength // → 16
   ```
 - [ ] [13.1.2] Resizable result can be grown:
   ```js
-  const result = ArrayBuffer.concat([new ArrayBuffer(4)], { resizable: true, length: 16 });
+  const result = ArrayBuffer.fromList([new ArrayBuffer(4)], { resizable: true, length: 16 });
   result.resize(8);
   result.byteLength // → 8
   ```
 - [ ] [13.1.3] Resizable result can be shrunk:
   ```js
-  const result = ArrayBuffer.concat([new ArrayBuffer(4)], { resizable: true, length: 16 });
+  const result = ArrayBuffer.fromList([new ArrayBuffer(4)], { resizable: true, length: 16 });
   result.resize(2);
   result.byteLength // → 2
   ```
 
 ### 13.2 Resizable without explicit length (maxByteLength = totalByteLength)
 
-- [ ] [13.2.1] `ArrayBuffer.concat([new ArrayBuffer(4)], { resizable: true })` → `byteLength === 4`, `maxByteLength === 4` (buffer already at max)
+- [ ] [13.2.1] `ArrayBuffer.fromList([new ArrayBuffer(4)], { resizable: true })` → `byteLength === 4`, `maxByteLength === 4` (buffer already at max)
 - [ ] [13.2.2] Can be shrunk but not grown beyond totalByteLength:
   ```js
-  const result = ArrayBuffer.concat([new ArrayBuffer(4)], { resizable: true });
+  const result = ArrayBuffer.fromList([new ArrayBuffer(4)], { resizable: true });
   result.resize(2); // works
   result.resize(5); // → RangeError (exceeds maxByteLength)
   ```
@@ -611,7 +611,7 @@ Note: As with §4, creating buffers large enough to trigger this may be implemen
   ```js
   const ab1 = new ArrayBuffer(4);
   const ab2 = new ArrayBuffer(4);
-  const result = ArrayBuffer.concat([ab1, ab2], { resizable: true, length: 6 });
+  const result = ArrayBuffer.fromList([ab1, ab2], { resizable: true, length: 6 });
   result.byteLength // → 6 (clamped: min(8, 6))
   result.maxByteLength // → 6
   ```
@@ -620,7 +620,7 @@ Note: As with §4, creating buffers large enough to trigger this may be implemen
 
 - [ ] [13.4.1] `byteLength` equals total data, `maxByteLength` equals `length`:
   ```js
-  const result = ArrayBuffer.concat([new ArrayBuffer(4)], { resizable: true, length: 32 });
+  const result = ArrayBuffer.fromList([new ArrayBuffer(4)], { resizable: true, length: 32 });
   result.byteLength // → 4 (actual data)
   result.maxByteLength // → 32 (room to grow)
   ```
@@ -631,19 +631,19 @@ Note: As with §4, creating buffers large enough to trigger this may be implemen
   ```js
   const ab = new ArrayBuffer(4);
   new Uint8Array(ab).set([1, 2, 3, 4]);
-  const result = ArrayBuffer.concat([ab], { resizable: true, length: 16 });
+  const result = ArrayBuffer.fromList([ab], { resizable: true, length: 16 });
   new Uint8Array(result, 0, 4) // → [1, 2, 3, 4]
   ```
 
 ---
 
-## 14. `ArrayBuffer.concat` — Immutable Option
+## 14. `ArrayBuffer.fromList` — Immutable Option
 
 Note: These tests depend on the [Immutable ArrayBuffer proposal](https://github.com/tc39/proposal-immutable-arraybuffer).
 
 ### 14.1 Basic immutable result
 
-- [ ] [14.1.1] `ArrayBuffer.concat([new ArrayBuffer(4)], { immutable: true })` → result has `immutable === true`
+- [ ] [14.1.1] `ArrayBuffer.fromList([new ArrayBuffer(4)], { immutable: true })` → result has `immutable === true`
 - [ ] [14.1.2] Immutable result cannot be resized → TypeError
 - [ ] [14.1.3] Immutable result cannot be detached/transferred → TypeError
 
@@ -653,22 +653,22 @@ Note: These tests depend on the [Immutable ArrayBuffer proposal](https://github.
   ```js
   const ab = new ArrayBuffer(4);
   new Uint8Array(ab).set([1, 2, 3, 4]);
-  const result = ArrayBuffer.concat([ab], { immutable: true });
+  const result = ArrayBuffer.fromList([ab], { immutable: true });
   new Uint8Array(result) // → [1, 2, 3, 4]
   ```
 
 ### 14.3 Immutable with explicit length
 
-- [ ] [14.3.1] Truncation: `ArrayBuffer.concat([new ArrayBuffer(8)], { immutable: true, length: 4 })` → immutable, byteLength 4
-- [ ] [14.3.2] Zero-fill: `ArrayBuffer.concat([new ArrayBuffer(4)], { immutable: true, length: 8 })` → immutable, byteLength 8
+- [ ] [14.3.1] Truncation: `ArrayBuffer.fromList([new ArrayBuffer(8)], { immutable: true, length: 4 })` → immutable, byteLength 4
+- [ ] [14.3.2] Zero-fill: `ArrayBuffer.fromList([new ArrayBuffer(4)], { immutable: true, length: 8 })` → immutable, byteLength 8
 
 ### 14.4 Immutable with empty inputs
 
-- [ ] [14.4.1] `ArrayBuffer.concat([], { immutable: true })` → immutable ArrayBuffer of byteLength 0
+- [ ] [14.4.1] `ArrayBuffer.fromList([], { immutable: true })` → immutable ArrayBuffer of byteLength 0
 
 ---
 
-## 15. `ArrayBuffer.concat` — Overflow Check on `totalByteLength`
+## 15. `ArrayBuffer.fromList` — Overflow Check on `totalByteLength`
 
 Covered in §10. Included here as a cross-reference.
 
@@ -676,41 +676,41 @@ Covered in §10. Included here as a cross-reference.
 
 ## 16. Evaluation Order and Observable Side Effects
 
-### 16.1 `%TypedArray%.concat` evaluation order
+### 16.1 `%TypedArray%.fromList` evaluation order
 
 - [ ] [16.1.1] `this` validation occurs before items iteration:
   ```js
   let iteratorCalled = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
-  try { %TypedArray%.concat.call(42, items); } catch(e) {}
+  try { %TypedArray%.fromList.call(42, items); } catch(e) {}
   iteratorCalled // → false
   ```
 - [ ] [16.1.2] Items iteration (step 6) occurs before length validation (step 8):
   ```js
   let iteratorCalled = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
-  try { Uint8Array.concat(items, NaN); } catch(e) {}
+  try { Uint8Array.fromList(items, NaN); } catch(e) {}
   iteratorCalled // → true (items iterated before length is checked)
   ```
 
 - [ ] [16.1.3] Length validation (step 8) occurs before individual item validation (step 10). Items are collected first, then length is checked, then each item is validated:
   ```js
   // 'bad' fails ValidateIntegralNumber at step 8 before items are validated at step 10
-  Uint8Array.concat([42], 'bad') // → TypeError from length validation ('bad' is not a Number)
+  Uint8Array.fromList([42], 'bad') // → TypeError from length validation ('bad' is not a Number)
   ```
 
 - [ ] [16.1.4] Length range check occurs before item type checking:
   ```js
-  Uint8Array.concat([new Int16Array([1])], -1) // → RangeError (from length, not TypeError from type mismatch)
+  Uint8Array.fromList([new Int16Array([1])], -1) // → RangeError (from length, not TypeError from type mismatch)
   ```
 
-### 16.2 `ArrayBuffer.concat` evaluation order
+### 16.2 `ArrayBuffer.fromList` evaluation order
 
 - [ ] [16.2.1] Options processing (steps 1–7) occurs before items iteration (step 8, `GetConcatenationSources`):
   ```js
   let iteratorCalled = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
-  try { ArrayBuffer.concat(items, 42); } catch(e) {} // options type check error at step 1
+  try { ArrayBuffer.fromList(items, 42); } catch(e) {} // options type check error at step 1
   iteratorCalled // → false (options checked at step 1, before items iterated at step 8)
   ```
 - [ ] [16.2.2] Options property access occurs before items iteration:
@@ -719,7 +719,7 @@ Covered in §10. Included here as a cross-reference.
   let optionsAccessed = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
   const options = { get length() { optionsAccessed = true; return 0; } };
-  ArrayBuffer.concat(items, options);
+  ArrayBuffer.fromList(items, options);
   optionsAccessed // → true
   iteratorCalled // → true
   // optionsAccessed becomes true before iteratorCalled
@@ -728,36 +728,36 @@ Covered in §10. Included here as a cross-reference.
   ```js
   let iteratorCalled = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
-  try { ArrayBuffer.concat(items, { resizable: true, immutable: true }); } catch(e) {} // → TypeError (mutual exclusion)
+  try { ArrayBuffer.fromList(items, { resizable: true, immutable: true }); } catch(e) {} // → TypeError (mutual exclusion)
   iteratorCalled // → false (mutual exclusion checked before iteration)
   ```
 - [ ] [16.2.4] Length validation occurs before items iteration:
   ```js
   let iteratorCalled = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
-  try { ArrayBuffer.concat(items, { length: 'bad' }); } catch(e) {} // → TypeError from length validation
+  try { ArrayBuffer.fromList(items, { length: 'bad' }); } catch(e) {} // → TypeError from length validation
   iteratorCalled // → false (length validated before iteration)
   ```
 - [ ] [16.2.2] Options processing (steps 4–10) occurs before item validation (step 11, `GetConcatenationSources`):
   ```js
   const detached = new ArrayBuffer(4);
   detached.transfer();
-  ArrayBuffer.concat([detached], { length: 'bad' }) // → TypeError from length validation (step 8)
+  ArrayBuffer.fromList([detached], { length: 'bad' }) // → TypeError from length validation (step 8)
   ```
 - [ ] [16.2.3] `resizable`/`immutable` mutual exclusion check (step 10) occurs before item validation (step 11):
   ```js
   const detached = new ArrayBuffer(4);
   detached.transfer();
-  ArrayBuffer.concat([detached], { resizable: true, immutable: true }) // → TypeError (mutual exclusion)
+  ArrayBuffer.fromList([detached], { resizable: true, immutable: true }) // → TypeError (mutual exclusion)
   ```
 
-### 16.3 `SharedArrayBuffer.concat` evaluation order
+### 16.3 `SharedArrayBuffer.fromList` evaluation order
 
 - [ ] [16.3.1] Options processing (steps 1–6) occurs before items iteration (step 7, `GetConcatenationSources`):
   ```js
   let iteratorCalled = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
-  try { SharedArrayBuffer.concat(items, 42); } catch(e) {} // options type check error at step 1
+  try { SharedArrayBuffer.fromList(items, 42); } catch(e) {} // options type check error at step 1
   iteratorCalled // → false (options checked at step 1, before items iterated at step 7)
   ```
 - [ ] [16.3.2] Options property access occurs before items iteration:
@@ -766,7 +766,7 @@ Covered in §10. Included here as a cross-reference.
   let optionsAccessed = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
   const options = { get length() { optionsAccessed = true; return 0; } };
-  SharedArrayBuffer.concat(items, options);
+  SharedArrayBuffer.fromList(items, options);
   optionsAccessed // → true
   iteratorCalled // → true
   // optionsAccessed becomes true before iteratorCalled
@@ -775,19 +775,19 @@ Covered in §10. Included here as a cross-reference.
   ```js
   let iteratorCalled = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
-  try { SharedArrayBuffer.concat(items, { length: 'bad' }); } catch(e) {} // → TypeError from length validation
+  try { SharedArrayBuffer.fromList(items, { length: 'bad' }); } catch(e) {} // → TypeError from length validation
   iteratorCalled // → false (length validated before iteration)
   ```
 
 ### 16.4 Items iterator with side effects
 
-- [ ] [16.4.1] `%TypedArray%.concat`: Custom iterable that tracks iteration count → all items collected before any item validation
-- [ ] [16.4.2] `ArrayBuffer.concat`: Custom iterable that tracks iteration count → all items collected before any item validation; options processed before iteration
-- [ ] [16.4.3] `SharedArrayBuffer.concat`: Custom iterable that tracks iteration count → all items collected before any item validation; options processed before iteration
+- [ ] [16.4.1] `%TypedArray%.fromList`: Custom iterable that tracks iteration count → all items collected before any item validation
+- [ ] [16.4.2] `ArrayBuffer.fromList`: Custom iterable that tracks iteration count → all items collected before any item validation; options processed before iteration
+- [ ] [16.4.3] `SharedArrayBuffer.fromList`: Custom iterable that tracks iteration count → all items collected before any item validation; options processed before iteration
 
 ### 16.5 No user code after GetConcatenationSources
 
-- [ ] [16.5.1] `ArrayBuffer.concat`: After items are iterated and validated in GetConcatenationSources, no user code can run:
+- [ ] [16.5.1] `ArrayBuffer.fromList`: After items are iterated and validated in GetConcatenationSources, no user code can run:
   ```js
   // Options getter cannot affect items after they are collected
   let phase = 'start';
@@ -804,58 +804,58 @@ Covered in §10. Included here as a cross-reference.
       return undefined;
     }
   };
-  ArrayBuffer.concat(items, options);
+  ArrayBuffer.fromList(items, options);
   // phase transitions: 'start' → 'options' → 'iterating'
   // (options accessed first, then iteration happens)
   ```
-- [ ] [16.5.2] `SharedArrayBuffer.concat`: Same guarantee as ArrayBuffer.concat
+- [ ] [16.5.2] `SharedArrayBuffer.fromList`: Same guarantee as ArrayBuffer.fromList
 
 ---
 
 ## 17. Property and Prototype
 
-### 17.1 `%TypedArray%.concat` method existence
+### 17.1 `%TypedArray%.fromList` method existence
 
-- [ ] [17.1.1] `typeof Uint8Array.concat` → `'function'`
-- [ ] [17.1.2] `Uint8Array.concat === Int32Array.concat` → true (shared on %TypedArray%)
+- [ ] [17.1.1] `typeof Uint8Array.fromList` → `'function'`
+- [ ] [17.1.2] `Uint8Array.fromList === Int32Array.fromList` → true (shared on %TypedArray%)
 
-### 17.2 `%TypedArray%.concat` method properties
+### 17.2 `%TypedArray%.fromList` method properties
 
-- [ ] [17.2.1] `Uint8Array.concat.length` → 1 (one required parameter: `items`)
-- [ ] [17.2.2] `Uint8Array.concat.name` → `'concat'`
+- [ ] [17.2.1] `Uint8Array.fromList.length` → 1 (one required parameter: `items`)
+- [ ] [17.2.2] `Uint8Array.fromList.name` → `'fromList'`
 
-### 17.3 `ArrayBuffer.concat` method existence
+### 17.3 `ArrayBuffer.fromList` method existence
 
-- [ ] [17.3.1] `typeof ArrayBuffer.concat` → `'function'`
+- [ ] [17.3.1] `typeof ArrayBuffer.fromList` → `'function'`
 
-### 17.4 `ArrayBuffer.concat` method properties
+### 17.4 `ArrayBuffer.fromList` method properties
 
-- [ ] [17.4.1] `ArrayBuffer.concat.length` → 1 (one required parameter: `items`)
-- [ ] [17.4.2] `ArrayBuffer.concat.name` → `'concat'`
+- [ ] [17.4.1] `ArrayBuffer.fromList.length` → 1 (one required parameter: `items`)
+- [ ] [17.4.2] `ArrayBuffer.fromList.name` → `'fromList'`
 
-### 17.5 `SharedArrayBuffer.concat` method existence
+### 17.5 `SharedArrayBuffer.fromList` method existence
 
-- [ ] [17.5.1] `typeof SharedArrayBuffer.concat` → `'function'`
+- [ ] [17.5.1] `typeof SharedArrayBuffer.fromList` → `'function'`
 
-### 17.6 `SharedArrayBuffer.concat` method properties
+### 17.6 `SharedArrayBuffer.fromList` method properties
 
-- [ ] [17.6.1] `SharedArrayBuffer.concat.length` → 1 (one required parameter: `items`)
-- [ ] [17.6.2] `SharedArrayBuffer.concat.name` → `'concat'`
+- [ ] [17.6.1] `SharedArrayBuffer.fromList.length` → 1 (one required parameter: `items`)
+- [ ] [17.6.2] `SharedArrayBuffer.fromList.name` → `'fromList'`
 
 ### 17.7 Not enumerable
 
-- [ ] [17.7.1] `Object.getOwnPropertyDescriptor(Uint8Array, 'concat').enumerable` → false
-- [ ] [17.7.2] `Object.getOwnPropertyDescriptor(ArrayBuffer, 'concat').enumerable` → false
-- [ ] [17.7.3] `Object.getOwnPropertyDescriptor(SharedArrayBuffer, 'concat').enumerable` → false
+- [ ] [17.7.1] `Object.getOwnPropertyDescriptor(Uint8Array, 'fromList').enumerable` → false
+- [ ] [17.7.2] `Object.getOwnPropertyDescriptor(ArrayBuffer, 'fromList').enumerable` → false
+- [ ] [17.7.3] `Object.getOwnPropertyDescriptor(SharedArrayBuffer, 'fromList').enumerable` → false
 
 ### 17.8 Configurable and writable
 
-- [ ] [17.8.1] `Object.getOwnPropertyDescriptor(Uint8Array, 'concat').configurable` → true
-- [ ] [17.8.2] `Object.getOwnPropertyDescriptor(Uint8Array, 'concat').writable` → true
-- [ ] [17.8.3] `Object.getOwnPropertyDescriptor(ArrayBuffer, 'concat').configurable` → true
-- [ ] [17.8.4] `Object.getOwnPropertyDescriptor(ArrayBuffer, 'concat').writable` → true
-- [ ] [17.8.5] `Object.getOwnPropertyDescriptor(SharedArrayBuffer, 'concat').configurable` → true
-- [ ] [17.8.6] `Object.getOwnPropertyDescriptor(SharedArrayBuffer, 'concat').writable` → true
+- [ ] [17.8.1] `Object.getOwnPropertyDescriptor(Uint8Array, 'fromList').configurable` → true
+- [ ] [17.8.2] `Object.getOwnPropertyDescriptor(Uint8Array, 'fromList').writable` → true
+- [ ] [17.8.3] `Object.getOwnPropertyDescriptor(ArrayBuffer, 'fromList').configurable` → true
+- [ ] [17.8.4] `Object.getOwnPropertyDescriptor(ArrayBuffer, 'fromList').writable` → true
+- [ ] [17.8.5] `Object.getOwnPropertyDescriptor(SharedArrayBuffer, 'fromList').configurable` → true
+- [ ] [17.8.6] `Object.getOwnPropertyDescriptor(SharedArrayBuffer, 'fromList').writable` → true
 
 ---
 
@@ -863,14 +863,14 @@ Covered in §10. Included here as a cross-reference.
 
 The key invariant is that only the **current** `byteLength` of a resizable ArrayBuffer is used, never the `maxByteLength`. For TypedArray views over resizable buffers, only the currently-visible elements are copied. The `maxByteLength` capacity beyond `byteLength` is uninitialized memory and must never be included.
 
-### 18.1 `%TypedArray%.concat` — Only current elements are copied (not max capacity)
+### 18.1 `%TypedArray%.fromList` — Only current elements are copied (not max capacity)
 
 - [ ] [18.1.1] Auto-length TypedArray over a resizable buffer — copies only current elements, not max capacity:
   ```js
   const rab = new ArrayBuffer(4, { maxByteLength: 32 });
   const u8 = new Uint8Array(rab); // auto-length, tracks byteLength
   u8.set([1, 2, 3, 4]);
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   result.length // → 4 (not 32)
   new Uint8Array(result) // → [1, 2, 3, 4]
   ```
@@ -879,7 +879,7 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const rab = new ArrayBuffer(16, { maxByteLength: 64 });
   new Uint8Array(rab).set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
   const u8 = new Uint8Array(rab, 0, 4); // fixed-length: 4 elements
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   result.length // → 4 (not 16 or 64)
   new Uint8Array(result) // → [1, 2, 3, 4]
   ```
@@ -891,7 +891,7 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const b = new Uint8Array(rab2);
   a.set([1, 2, 3]);
   b.set([4, 5]);
-  const result = Uint8Array.concat([a, b]);
+  const result = Uint8Array.fromList([a, b]);
   result.length // → 5 (3 + 2, not 100 + 200)
   new Uint8Array(result) // → [1, 2, 3, 4, 5]
   ```
@@ -901,7 +901,7 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const u8 = new Uint8Array(rab);
   u8.set([1, 2, 3, 4]);
   rab.resize(16); // grow to 16 bytes; u8.length is now 16
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   result.length // → 16 (auto-length tracks current byteLength)
   // First 4 bytes are [1,2,3,4], remaining 12 are 0 (zero-initialized by resize)
   ```
@@ -911,7 +911,7 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const u8 = new Uint8Array(rab);
   u8.set([1, 2, 3, 4, 5, 6, 7, 8]);
   rab.resize(3); // shrink to 3 bytes; u8.length is now 3
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   result.length // → 3
   new Uint8Array(result) // → [1, 2, 3]
   ```
@@ -920,26 +920,26 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const rab = new ArrayBuffer(8, { maxByteLength: 64 });
   const i32 = new Int32Array(rab); // auto-length: 2 elements (8 / 4)
   i32.set([100, 200]);
-  const result = Int32Array.concat([i32]);
+  const result = Int32Array.fromList([i32]);
   result.length // → 2 (not 64 / 4 = 16)
   new Int32Array(result) // → [100, 200]
   ```
 
-### 18.2 `%TypedArray%.concat` — Resizable buffer edge cases
+### 18.2 `%TypedArray%.fromList` — Resizable buffer edge cases
 
 - [ ] [18.2.1] Fixed-length TypedArray whose resizable buffer has been shrunk below the fixed range → TypeError from `ValidateTypedArray`:
   ```js
   const rab = new ArrayBuffer(8, { maxByteLength: 16 });
   const u8 = new Uint8Array(rab, 0, 8); // fixed-length: 8
   rab.resize(4); // shrink below the fixed range
-  Uint8Array.concat([u8]) // → TypeError (TypedArray is out of bounds)
+  Uint8Array.fromList([u8]) // → TypeError (TypedArray is out of bounds)
   ```
 - [ ] [18.2.2] Fixed-length TypedArray with byteOffset, buffer shrunk below offset → TypeError:
   ```js
   const rab = new ArrayBuffer(16, { maxByteLength: 32 });
   const u8 = new Uint8Array(rab, 8, 4); // offset 8, length 4
   rab.resize(4); // shrink below the offset
-  Uint8Array.concat([u8]) // → TypeError (out of bounds)
+  Uint8Array.fromList([u8]) // → TypeError (out of bounds)
   ```
 - [ ] [18.2.3] Auto-length TypedArray over a buffer resized to 0 → copies zero elements:
   ```js
@@ -947,17 +947,17 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const u8 = new Uint8Array(rab);
   u8.set([1, 2, 3, 4, 5, 6, 7, 8]);
   rab.resize(0);
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   result.length // → 0
   ```
 
-### 18.3 `ArrayBuffer.concat` — Only current byteLength is copied (not maxByteLength)
+### 18.3 `ArrayBuffer.fromList` — Only current byteLength is copied (not maxByteLength)
 
 - [ ] [18.3.1] Resizable ArrayBuffer passed directly — copies current byteLength, ignores maxByteLength:
   ```js
   const rab = new ArrayBuffer(4, { maxByteLength: 64 });
   new Uint8Array(rab).set([1, 2, 3, 4]);
-  const result = ArrayBuffer.concat([rab]);
+  const result = ArrayBuffer.fromList([rab]);
   result.byteLength // → 4 (not 64)
   new Uint8Array(result) // → [1, 2, 3, 4]
   ```
@@ -967,7 +967,7 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const rab2 = new ArrayBuffer(2, { maxByteLength: 200 });
   new Uint8Array(rab1).set([1, 2, 3]);
   new Uint8Array(rab2).set([4, 5]);
-  const result = ArrayBuffer.concat([rab1, rab2]);
+  const result = ArrayBuffer.fromList([rab1, rab2]);
   result.byteLength // → 5 (not 300)
   new Uint8Array(result) // → [1, 2, 3, 4, 5]
   ```
@@ -976,7 +976,7 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const rab = new ArrayBuffer(4, { maxByteLength: 32 });
   new Uint8Array(rab).set([1, 2, 3, 4]);
   rab.resize(8); // grow; bytes 4-7 are zero-initialized
-  const result = ArrayBuffer.concat([rab]);
+  const result = ArrayBuffer.fromList([rab]);
   result.byteLength // → 8
   new Uint8Array(result) // → [1, 2, 3, 4, 0, 0, 0, 0]
   ```
@@ -985,7 +985,7 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const rab = new ArrayBuffer(8, { maxByteLength: 32 });
   new Uint8Array(rab).set([1, 2, 3, 4, 5, 6, 7, 8]);
   rab.resize(3);
-  const result = ArrayBuffer.concat([rab]);
+  const result = ArrayBuffer.fromList([rab]);
   result.byteLength // → 3
   new Uint8Array(result) // → [1, 2, 3]
   ```
@@ -993,18 +993,18 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   ```js
   const rab = new ArrayBuffer(8, { maxByteLength: 16 });
   rab.resize(0);
-  const result = ArrayBuffer.concat([rab, new ArrayBuffer(2)]);
+  const result = ArrayBuffer.fromList([rab, new ArrayBuffer(2)]);
   result.byteLength // → 2
   ```
 
-### 18.4 `ArrayBuffer.concat` — TypedArray/DataView over resizable buffers (viewed portion only)
+### 18.4 `ArrayBuffer.fromList` — TypedArray/DataView over resizable buffers (viewed portion only)
 
 - [ ] [18.4.1] Auto-length TypedArray over resizable buffer — only current viewed bytes:
   ```js
   const rab = new ArrayBuffer(4, { maxByteLength: 64 });
   new Uint8Array(rab).set([10, 20, 30, 40]);
   const u8 = new Uint8Array(rab); // auto-length
-  const result = ArrayBuffer.concat([u8]);
+  const result = ArrayBuffer.fromList([u8]);
   result.byteLength // → 4 (not 64)
   new Uint8Array(result) // → [10, 20, 30, 40]
   ```
@@ -1013,7 +1013,7 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const rab = new ArrayBuffer(16, { maxByteLength: 64 });
   new Uint8Array(rab).set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
   const u8 = new Uint8Array(rab, 4, 4); // bytes 4-7: [5, 6, 7, 8]
-  const result = ArrayBuffer.concat([u8]);
+  const result = ArrayBuffer.fromList([u8]);
   result.byteLength // → 4 (not 64 or 16)
   new Uint8Array(result) // → [5, 6, 7, 8]
   ```
@@ -1022,7 +1022,7 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const rab = new ArrayBuffer(4, { maxByteLength: 64 });
   new Uint8Array(rab).set([10, 20, 30, 40]);
   const dv = new DataView(rab); // auto-length
-  const result = ArrayBuffer.concat([dv]);
+  const result = ArrayBuffer.fromList([dv]);
   result.byteLength // → 4 (not 64)
   new Uint8Array(result) // → [10, 20, 30, 40]
   ```
@@ -1031,7 +1031,7 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const rab = new ArrayBuffer(16, { maxByteLength: 64 });
   new Uint8Array(rab).set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
   const dv = new DataView(rab, 4, 4); // bytes 4-7
-  const result = ArrayBuffer.concat([dv]);
+  const result = ArrayBuffer.fromList([dv]);
   result.byteLength // → 4
   new Uint8Array(result) // → [5, 6, 7, 8]
   ```
@@ -1040,7 +1040,7 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const rab = new ArrayBuffer(8, { maxByteLength: 64 });
   const i32 = new Int32Array(rab); // 2 elements, 8 bytes
   i32.set([100, 200]);
-  const result = ArrayBuffer.concat([i32]);
+  const result = ArrayBuffer.fromList([i32]);
   result.byteLength // → 8 (not 64)
   ```
 - [ ] [18.4.6] Fixed-length TypedArray whose resizable buffer was shrunk below range → TypeError:
@@ -1048,29 +1048,29 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const rab = new ArrayBuffer(8, { maxByteLength: 16 });
   const u8 = new Uint8Array(rab, 0, 8);
   rab.resize(4);
-  ArrayBuffer.concat([u8]) // → TypeError (ValidateTypedArray: out of bounds)
+  ArrayBuffer.fromList([u8]) // → TypeError (ValidateTypedArray: out of bounds)
   ```
 - [ ] [18.4.7] Fixed-length DataView whose resizable buffer was shrunk below range → TypeError:
   ```js
   const rab = new ArrayBuffer(8, { maxByteLength: 16 });
   const dv = new DataView(rab, 0, 8);
   rab.resize(4);
-  ArrayBuffer.concat([dv]) // → TypeError (IsViewOutOfBounds)
+  ArrayBuffer.fromList([dv]) // → TypeError (IsViewOutOfBounds)
   ```
 
 ### 18.5 Mixed resizable and fixed-size inputs
 
-- [ ] [18.5.1] `%TypedArray%.concat` with a mix of resizable-backed and fixed-backed TypedArrays:
+- [ ] [18.5.1] `%TypedArray%.fromList` with a mix of resizable-backed and fixed-backed TypedArrays:
   ```js
   const rab = new ArrayBuffer(3, { maxByteLength: 100 });
   new Uint8Array(rab).set([1, 2, 3]);
   const resizableView = new Uint8Array(rab);
   const fixedView = new Uint8Array([4, 5]);
-  const result = Uint8Array.concat([resizableView, fixedView]);
+  const result = Uint8Array.fromList([resizableView, fixedView]);
   result.length // → 5
   new Uint8Array(result) // → [1, 2, 3, 4, 5]
   ```
-- [ ] [18.5.2] `ArrayBuffer.concat` with resizable ArrayBuffer, fixed ArrayBuffer, and TypedArray over resizable:
+- [ ] [18.5.2] `ArrayBuffer.fromList` with resizable ArrayBuffer, fixed ArrayBuffer, and TypedArray over resizable:
   ```js
   const rab = new ArrayBuffer(2, { maxByteLength: 100 });
   new Uint8Array(rab).set([1, 2]);
@@ -1079,7 +1079,7 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
   const rab2 = new ArrayBuffer(2, { maxByteLength: 200 });
   new Uint8Array(rab2).set([5, 6]);
   const view = new Uint8Array(rab2);
-  const result = ArrayBuffer.concat([rab, fixed, view]);
+  const result = ArrayBuffer.fromList([rab, fixed, view]);
   result.byteLength // → 6 (2 + 2 + 2, not 100 + 2 + 200)
   new Uint8Array(result) // → [1, 2, 3, 4, 5, 6]
   ```
@@ -1088,21 +1088,21 @@ The key invariant is that only the **current** `byteLength` of a resizable Array
 
 ## 19. Items Iterable Variations
 
-Both `%TypedArray%.concat` and `ArrayBuffer.concat` accept any iterable for the `items` parameter.
+Both `%TypedArray%.fromList` and `ArrayBuffer.fromList` accept any iterable for the `items` parameter.
 
-### 19.1 `%TypedArray%.concat` iterable types
+### 19.1 `%TypedArray%.fromList` iterable types
 
-- [ ] [19.1.1] Plain Array: `Uint8Array.concat([new Uint8Array([1]), new Uint8Array([2])])` → works
+- [ ] [19.1.1] Plain Array: `Uint8Array.fromList([new Uint8Array([1]), new Uint8Array([2])])` → works
 - [ ] [19.1.2] Generator:
   ```js
   function* gen() { yield new Uint8Array([1]); yield new Uint8Array([2]); }
-  Uint8Array.concat(gen()) // → Uint8Array [1, 2]
+  Uint8Array.fromList(gen()) // → Uint8Array [1, 2]
   ```
 - [ ] [19.1.3] Set:
   ```js
   const a = new Uint8Array([1]);
   const b = new Uint8Array([2]);
-  Uint8Array.concat(new Set([a, b])) // → Uint8Array [1, 2]
+  Uint8Array.fromList(new Set([a, b])) // → Uint8Array [1, 2]
   ```
 - [ ] [19.1.4] Custom iterable:
   ```js
@@ -1113,38 +1113,38 @@ Both `%TypedArray%.concat` and `ArrayBuffer.concat` accept any iterable for the 
       return { next() { return i < arrays.length ? { value: arrays[i++], done: false } : { done: true }; } };
     }
   };
-  Uint8Array.concat(items) // → Uint8Array [1, 2]
+  Uint8Array.fromList(items) // → Uint8Array [1, 2]
   ```
 
-### 19.2 `ArrayBuffer.concat` iterable types
+### 19.2 `ArrayBuffer.fromList` iterable types
 
-- [ ] [19.2.1] Plain Array: `ArrayBuffer.concat([new ArrayBuffer(2), new ArrayBuffer(2)])` → works
+- [ ] [19.2.1] Plain Array: `ArrayBuffer.fromList([new ArrayBuffer(2), new ArrayBuffer(2)])` → works
 - [ ] [19.2.2] Generator:
   ```js
   function* gen() { yield new ArrayBuffer(2); yield new Uint8Array([1, 2]); }
-  ArrayBuffer.concat(gen()) // → ArrayBuffer of byteLength 4
+  ArrayBuffer.fromList(gen()) // → ArrayBuffer of byteLength 4
   ```
 - [ ] [19.2.3] Set of mixed types:
   ```js
-  ArrayBuffer.concat(new Set([new ArrayBuffer(2), new Uint8Array([1, 2]), new DataView(new ArrayBuffer(2))]))
+  ArrayBuffer.fromList(new Set([new ArrayBuffer(2), new Uint8Array([1, 2]), new DataView(new ArrayBuffer(2))]))
   // → ArrayBuffer of byteLength 6
   ```
 
 ---
 
-## 20. `%TypedArray%.concat` — Copy Loop Edge Cases
+## 20. `%TypedArray%.fromList` — Copy Loop Edge Cases
 
 ### 20.1 Short-circuit when result is full
 
 - [ ] [20.1.1] With `length: 0`, no items are copied even if present:
   ```js
   const a = new Uint8Array([1, 2, 3]);
-  const result = Uint8Array.concat([a], 0);
+  const result = Uint8Array.fromList([a], 0);
   result.length // → 0
   ```
 - [ ] [20.1.2] With `length: 2` and items totalling 6 elements, only the first 2 elements are in the result:
   ```js
-  const result = Uint8Array.concat([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])], 2);
+  const result = Uint8Array.fromList([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])], 2);
   // result → Uint8Array [1, 2]
   ```
 
@@ -1152,7 +1152,7 @@ Both `%TypedArray%.concat` and `ArrayBuffer.concat` accept any iterable for the 
 
 - [ ] [20.2.1] Truncation splits an item's elements:
   ```js
-  const result = Uint8Array.concat([new Uint8Array([1, 2]), new Uint8Array([3, 4, 5])], 4);
+  const result = Uint8Array.fromList([new Uint8Array([1, 2]), new Uint8Array([3, 4, 5])], 4);
   // result → Uint8Array [1, 2, 3, 4] (second item truncated from 3 elements to 2)
   ```
 
@@ -1160,19 +1160,19 @@ Both `%TypedArray%.concat` and `ArrayBuffer.concat` accept any iterable for the 
 
 - [ ] [20.3.1] Mix of empty and non-empty items:
   ```js
-  const result = Uint8Array.concat([new Uint8Array([]), new Uint8Array([1]), new Uint8Array([]), new Uint8Array([2])]);
+  const result = Uint8Array.fromList([new Uint8Array([]), new Uint8Array([1]), new Uint8Array([]), new Uint8Array([2])]);
   // result → Uint8Array [1, 2]
   ```
 
 ---
 
-## 21. `ArrayBuffer.concat` — Copy Loop Edge Cases
+## 21. `ArrayBuffer.fromList` — Copy Loop Edge Cases
 
 ### 21.1 Short-circuit when result is full
 
 - [ ] [21.1.1] With `length: 0`, no bytes are copied:
   ```js
-  const result = ArrayBuffer.concat([new ArrayBuffer(4)], { length: 0 });
+  const result = ArrayBuffer.fromList([new ArrayBuffer(4)], { length: 0 });
   result.byteLength // → 0
   ```
 - [ ] [21.1.2] With `length: 2` and items totalling 8 bytes, only the first 2 bytes are in the result
@@ -1187,17 +1187,17 @@ Both `%TypedArray%.concat` and `ArrayBuffer.concat` accept any iterable for the 
   new Uint8Array(ab2).set([4, 5, 6]);
   const ab3 = new ArrayBuffer(3);
   new Uint8Array(ab3).set([7, 8, 9]);
-  const result = ArrayBuffer.concat([ab1, ab2, ab3], { length: 5 });
+  const result = ArrayBuffer.fromList([ab1, ab2, ab3], { length: 5 });
   // new Uint8Array(result) → [1, 2, 3, 4, 5]
   ```
 
 ### 21.3 Zero-length items in the mix
 
-- [ ] [21.3.1] `ArrayBuffer.concat([new ArrayBuffer(0), new ArrayBuffer(4), new ArrayBuffer(0)])` → byteLength 4, data from the middle item
+- [ ] [21.3.1] `ArrayBuffer.fromList([new ArrayBuffer(0), new ArrayBuffer(4), new ArrayBuffer(0)])` → byteLength 4, data from the middle item
 
 ---
 
-## 22. `ArrayBuffer.concat` — Immutable + Resizable Interaction
+## 22. `ArrayBuffer.fromList` — Immutable + Resizable Interaction
 
 ### 22.1 Mutually exclusive
 
@@ -1217,7 +1217,7 @@ Both `%TypedArray%.concat` and `ArrayBuffer.concat` accept any iterable for the 
 
 ## 23. Same Underlying Buffer / Overlapping Views
 
-### 23.1 `%TypedArray%.concat` — Multiple views of the same buffer
+### 23.1 `%TypedArray%.fromList` — Multiple views of the same buffer
 
 - [ ] [23.1.1] Two TypedArrays backed by the same ArrayBuffer at different offsets:
   ```js
@@ -1225,12 +1225,12 @@ Both `%TypedArray%.concat` and `ArrayBuffer.concat` accept any iterable for the 
   new Uint8Array(ab).set([1, 2, 3, 4, 5, 6, 7, 8]);
   const a = new Uint8Array(ab, 0, 4); // [1, 2, 3, 4]
   const b = new Uint8Array(ab, 4, 4); // [5, 6, 7, 8]
-  Uint8Array.concat([a, b]) // → Uint8Array [1, 2, 3, 4, 5, 6, 7, 8]
+  Uint8Array.fromList([a, b]) // → Uint8Array [1, 2, 3, 4, 5, 6, 7, 8]
   ```
 - [ ] [23.1.2] Same TypedArray passed twice:
   ```js
   const a = new Uint8Array([1, 2]);
-  Uint8Array.concat([a, a]) // → Uint8Array [1, 2, 1, 2]
+  Uint8Array.fromList([a, a]) // → Uint8Array [1, 2, 1, 2]
   ```
 - [ ] [23.1.3] Overlapping views:
   ```js
@@ -1238,10 +1238,10 @@ Both `%TypedArray%.concat` and `ArrayBuffer.concat` accept any iterable for the 
   new Uint8Array(ab).set([1, 2, 3, 4, 5, 6]);
   const a = new Uint8Array(ab, 0, 4); // [1, 2, 3, 4]
   const b = new Uint8Array(ab, 2, 4); // [3, 4, 5, 6]
-  Uint8Array.concat([a, b]) // → Uint8Array [1, 2, 3, 4, 3, 4, 5, 6]
+  Uint8Array.fromList([a, b]) // → Uint8Array [1, 2, 3, 4, 3, 4, 5, 6]
   ```
 
-### 23.2 `ArrayBuffer.concat` — Same buffer via different views
+### 23.2 `ArrayBuffer.fromList` — Same buffer via different views
 
 - [ ] [23.2.1] Two TypedArrays viewing different parts of the same buffer:
   ```js
@@ -1249,14 +1249,14 @@ Both `%TypedArray%.concat` and `ArrayBuffer.concat` accept any iterable for the 
   new Uint8Array(ab).set([1, 2, 3, 4, 5, 6, 7, 8]);
   const a = new Uint8Array(ab, 0, 4);
   const b = new Uint8Array(ab, 4, 4);
-  const result = ArrayBuffer.concat([a, b]);
+  const result = ArrayBuffer.fromList([a, b]);
   // new Uint8Array(result) → [1, 2, 3, 4, 5, 6, 7, 8]
   ```
 - [ ] [23.2.2] Same ArrayBuffer passed twice as direct item:
   ```js
   const ab = new ArrayBuffer(4);
   new Uint8Array(ab).set([1, 2, 3, 4]);
-  const result = ArrayBuffer.concat([ab, ab]);
+  const result = ArrayBuffer.fromList([ab, ab]);
   // new Uint8Array(result) → [1, 2, 3, 4, 1, 2, 3, 4]
   ```
 - [ ] [23.2.3] TypedArray and DataView viewing the same buffer:
@@ -1265,7 +1265,7 @@ Both `%TypedArray%.concat` and `ArrayBuffer.concat` accept any iterable for the 
   new Uint8Array(ab).set([1, 2, 3, 4]);
   const u8 = new Uint8Array(ab, 0, 2);
   const dv = new DataView(ab, 2, 2);
-  const result = ArrayBuffer.concat([u8, dv]);
+  const result = ArrayBuffer.fromList([u8, dv]);
   // new Uint8Array(result) → [1, 2, 3, 4]
   ```
 
@@ -1275,13 +1275,13 @@ Both `%TypedArray%.concat` and `ArrayBuffer.concat` accept any iterable for the 
 
 ### 24.1 Many items
 
-- [ ] [24.1.1] `Uint8Array.concat` with 1000 single-element TypedArrays → result has 1000 elements in correct order
-- [ ] [24.1.2] `ArrayBuffer.concat` with 1000 single-byte ArrayBuffers → result has byteLength 1000
+- [ ] [24.1.1] `Uint8Array.fromList` with 1000 single-element TypedArrays → result has 1000 elements in correct order
+- [ ] [24.1.2] `ArrayBuffer.fromList` with 1000 single-byte ArrayBuffers → result has byteLength 1000
 
 ### 24.2 Large individual items
 
-- [ ] [24.2.1] `Uint8Array.concat` with a single 1MB TypedArray → result matches
-- [ ] [24.2.2] `ArrayBuffer.concat` with two 1MB ArrayBuffers → result has byteLength 2MB, data correct
+- [ ] [24.2.1] `Uint8Array.fromList` with a single 1MB TypedArray → result matches
+- [ ] [24.2.2] `ArrayBuffer.fromList` with two 1MB ArrayBuffers → result has byteLength 2MB, data correct
 
 ### 24.3 Combination of many small and few large
 
@@ -1293,7 +1293,7 @@ Both `%TypedArray%.concat` and `ArrayBuffer.concat` accept any iterable for the 
 
 The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[[ByteOffset]]`, `[[ViewedArrayBuffer]]`, `[[TypedArrayName]]`, `[[ArrayBufferData]]`, `[[ArrayBufferByteLength]]`) and use abstract operations (`TypedArrayLength`, `TypedArrayByteLength`, `ValidateTypedArray`, etc.) that bypass JavaScript-visible property access. These tests verify that overriding or shadowing properties has no observable effect on the result.
 
-### 25.1 `%TypedArray%.concat` — Overridden TypedArray properties
+### 25.1 `%TypedArray%.fromList` — Overridden TypedArray properties
 
 #### 25.1.1 Overridden `.length` on items
 
@@ -1301,7 +1301,7 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   ```js
   const u8 = new Uint8Array([1, 2, 3]);
   Object.defineProperty(u8, 'length', { value: 100 });
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   result.length // → 3 (uses [[ArrayLength]], not .length)
   new Uint8Array(result) // → [1, 2, 3]
   ```
@@ -1309,14 +1309,14 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   ```js
   const u8 = new Uint8Array([1, 2, 3, 4, 5]);
   Object.defineProperty(u8, 'length', { value: 1 });
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   result.length // → 5 (uses [[ArrayLength]], not .length)
   ```
 - [ ] [25.1.1.3] `.length` set to 0 on non-empty TypedArray:
   ```js
   const u8 = new Uint8Array([1, 2, 3]);
   Object.defineProperty(u8, 'length', { value: 0 });
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   result.length // → 3
   ```
 
@@ -1326,7 +1326,7 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   ```js
   const u8 = new Uint8Array([1, 2, 3]);
   Object.defineProperty(u8, 'byteLength', { value: 100 });
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   result.length // → 3 (not influenced by fake byteLength)
   ```
 
@@ -1338,7 +1338,7 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   new Uint8Array(ab).set([1, 2, 3, 4, 5, 6, 7, 8]);
   const u8 = new Uint8Array(ab, 2, 3); // views [3, 4, 5]
   Object.defineProperty(u8, 'byteOffset', { value: 0 });
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   // result → Uint8Array [3, 4, 5] (uses [[ByteOffset]], not .byteOffset)
   ```
 
@@ -1349,7 +1349,7 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   const u8 = new Uint8Array([1, 2, 3]);
   const fakeBuffer = new ArrayBuffer(100);
   Object.defineProperty(u8, 'buffer', { value: fakeBuffer });
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   result.length // → 3 (uses [[ViewedArrayBuffer]], not .buffer)
   new Uint8Array(result) // → [1, 2, 3]
   ```
@@ -1361,12 +1361,12 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   const a = new Uint8Array([1, 2]);
   const items = [a];
   items[Symbol.iterator] = function*() { yield a; yield a; yield a; };
-  const result = Uint8Array.concat(items);
+  const result = Uint8Array.fromList(items);
   result.length // → 6 (iterator is respected for the items iterable)
   new Uint8Array(result) // → [1, 2, 1, 2, 1, 2]
   ```
 
-### 25.2 `%TypedArray%.concat` — Overridden constructor properties
+### 25.2 `%TypedArray%.fromList` — Overridden constructor properties
 
 #### 25.2.1 Overridden `Symbol.species` or `@@species`
 
@@ -1374,11 +1374,11 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   ```js
   class MyUint8Array extends Uint8Array {}
   Object.defineProperty(Uint8Array, Symbol.species, { value: MyUint8Array });
-  const result = Uint8Array.concat([new Uint8Array([1, 2])]);
+  const result = Uint8Array.fromList([new Uint8Array([1, 2])]);
   result.constructor // → Uint8Array (not MyUint8Array; species is not consulted)
   ```
 
-### 25.3 `ArrayBuffer.concat` — Overridden ArrayBuffer properties
+### 25.3 `ArrayBuffer.fromList` — Overridden ArrayBuffer properties
 
 #### 25.3.1 Overridden `.byteLength` on ArrayBuffer items
 
@@ -1387,7 +1387,7 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   const ab = new ArrayBuffer(4);
   new Uint8Array(ab).set([1, 2, 3, 4]);
   Object.defineProperty(ab, 'byteLength', { value: 100 });
-  const result = ArrayBuffer.concat([ab]);
+  const result = ArrayBuffer.fromList([ab]);
   result.byteLength // → 4 (uses [[ArrayBufferByteLength]], not .byteLength)
   ```
 - [ ] [25.3.1.2] `Object.defineProperty` to decrease `.byteLength`:
@@ -1395,35 +1395,35 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   const ab = new ArrayBuffer(4);
   new Uint8Array(ab).set([1, 2, 3, 4]);
   Object.defineProperty(ab, 'byteLength', { value: 1 });
-  const result = ArrayBuffer.concat([ab]);
+  const result = ArrayBuffer.fromList([ab]);
   result.byteLength // → 4
   ```
 
-#### 25.3.2 Overridden properties on TypedArray items (used in ArrayBuffer.concat)
+#### 25.3.2 Overridden properties on TypedArray items (used in ArrayBuffer.fromList)
 
-- [ ] [25.3.2.1] Overridden `.byteLength` on TypedArray passed to `ArrayBuffer.concat`:
+- [ ] [25.3.2.1] Overridden `.byteLength` on TypedArray passed to `ArrayBuffer.fromList`:
   ```js
   const u8 = new Uint8Array([1, 2, 3, 4]);
   Object.defineProperty(u8, 'byteLength', { value: 100 });
-  const result = ArrayBuffer.concat([u8]);
+  const result = ArrayBuffer.fromList([u8]);
   result.byteLength // → 4 (uses TypedArrayByteLength, not .byteLength)
   ```
-- [ ] [25.3.2.2] Overridden `.byteOffset` on TypedArray passed to `ArrayBuffer.concat`:
+- [ ] [25.3.2.2] Overridden `.byteOffset` on TypedArray passed to `ArrayBuffer.fromList`:
   ```js
   const ab = new ArrayBuffer(8);
   new Uint8Array(ab).set([1, 2, 3, 4, 5, 6, 7, 8]);
   const u8 = new Uint8Array(ab, 4, 4); // views [5, 6, 7, 8]
   Object.defineProperty(u8, 'byteOffset', { value: 0 });
-  const result = ArrayBuffer.concat([u8]);
+  const result = ArrayBuffer.fromList([u8]);
   new Uint8Array(result) // → [5, 6, 7, 8] (uses [[ByteOffset]], not .byteOffset)
   ```
-- [ ] [25.3.2.3] Overridden `.buffer` on TypedArray passed to `ArrayBuffer.concat`:
+- [ ] [25.3.2.3] Overridden `.buffer` on TypedArray passed to `ArrayBuffer.fromList`:
   ```js
   const u8 = new Uint8Array([1, 2, 3]);
   const fakeBuffer = new ArrayBuffer(100);
   new Uint8Array(fakeBuffer).fill(0xFF);
   Object.defineProperty(u8, 'buffer', { value: fakeBuffer });
-  const result = ArrayBuffer.concat([u8]);
+  const result = ArrayBuffer.fromList([u8]);
   new Uint8Array(result) // → [1, 2, 3] (uses [[ViewedArrayBuffer]], not .buffer)
   ```
 
@@ -1435,7 +1435,7 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   new Uint8Array(ab).set([1, 2, 3, 4]);
   const dv = new DataView(ab);
   Object.defineProperty(dv, 'byteLength', { value: 100 });
-  const result = ArrayBuffer.concat([dv]);
+  const result = ArrayBuffer.fromList([dv]);
   result.byteLength // → 4 (uses GetViewByteLength, not .byteLength)
   ```
 - [ ] [25.3.3.2] Overridden `.byteOffset` on DataView:
@@ -1444,7 +1444,7 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   new Uint8Array(ab).set([1, 2, 3, 4, 5, 6, 7, 8]);
   const dv = new DataView(ab, 4, 4); // views [5, 6, 7, 8]
   Object.defineProperty(dv, 'byteOffset', { value: 0 });
-  const result = ArrayBuffer.concat([dv]);
+  const result = ArrayBuffer.fromList([dv]);
   new Uint8Array(result) // → [5, 6, 7, 8] (uses [[ByteOffset]], not .byteOffset)
   ```
 - [ ] [25.3.3.3] Overridden `.buffer` on DataView:
@@ -1453,28 +1453,28 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   new Uint8Array(ab).set([1, 2, 3, 4]);
   const dv = new DataView(ab);
   Object.defineProperty(dv, 'buffer', { value: new ArrayBuffer(100) });
-  const result = ArrayBuffer.concat([dv]);
+  const result = ArrayBuffer.fromList([dv]);
   new Uint8Array(result) // → [1, 2, 3, 4] (uses [[ViewedArrayBuffer]], not .buffer)
   ```
 
-### 25.4 `ArrayBuffer.concat` — Overridden options object accessors
+### 25.4 `ArrayBuffer.fromList` — Overridden options object accessors
 
 - [ ] [25.4.1] Options object with getter on `length` that has side effects:
   ```js
   let callCount = 0;
   const opts = { get length() { callCount++; return 4; } };
-  ArrayBuffer.concat([new ArrayBuffer(2)], opts);
+  ArrayBuffer.fromList([new ArrayBuffer(2)], opts);
   callCount // → 1 (Get is called once for "length")
   ```
 - [ ] [25.4.2] Options object with getter on `resizable` that throws:
   ```js
   const opts = { get resizable() { throw new Error('boom'); } };
-  ArrayBuffer.concat([], opts) // → Error('boom')
+  ArrayBuffer.fromList([], opts) // → Error('boom')
   ```
 - [ ] [25.4.3] Options object with getter on `immutable` that throws:
   ```js
   const opts = { resizable: false, get immutable() { throw new Error('boom'); } };
-  ArrayBuffer.concat([], opts) // → Error('boom')
+  ArrayBuffer.fromList([], opts) // → Error('boom')
   ```
 - [ ] [25.4.4] Options with `length` getter that modifies items (items already collected):
   ```js
@@ -1490,7 +1490,7 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   // Items are iterated at step 1, options read at step 2+
   // But item validation happens at step 10+ (after options), so detachment
   // will be caught during validation
-  ArrayBuffer.concat([ab], opts) // → TypeError (detached buffer)
+  ArrayBuffer.fromList([ab], opts) // → TypeError (detached buffer)
   ```
 
 ### 25.5 Prototype pollution
@@ -1500,7 +1500,7 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   const origDesc = Object.getOwnPropertyDescriptor(Uint8Array.prototype.__proto__, 'length');
   try {
     Object.defineProperty(Uint8Array.prototype.__proto__, 'length', { get() { return 9999; } });
-    const result = Uint8Array.concat([new Uint8Array([1, 2, 3])]);
+    const result = Uint8Array.fromList([new Uint8Array([1, 2, 3])]);
     result.length // → 3 (internal slot, not prototype getter)
   } finally {
     Object.defineProperty(Uint8Array.prototype.__proto__, 'length', origDesc);
@@ -1513,7 +1513,7 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
     Object.defineProperty(ArrayBuffer.prototype, 'byteLength', { get() { return 9999; } });
     const ab = new ArrayBuffer(4);
     new Uint8Array(ab).set([1, 2, 3, 4]);
-    const result = ArrayBuffer.concat([ab]);
+    const result = ArrayBuffer.fromList([ab]);
     result.byteLength // → 4
   } finally {
     Object.defineProperty(ArrayBuffer.prototype, 'byteLength', origDesc);
@@ -1523,7 +1523,7 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   ```js
   Object.prototype[Symbol.iterator] = function*() { yield new Uint8Array([99]); };
   try {
-    const result = Uint8Array.concat([new Uint8Array([1, 2])]);
+    const result = Uint8Array.fromList([new Uint8Array([1, 2])]);
     // Array's own Symbol.iterator is used, not Object.prototype's
     new Uint8Array(result) // → [1, 2]
   } finally {
@@ -1533,10 +1533,10 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
 
 ### 25.6 Subclass shenanigans
 
-- [ ] [25.6.1] Calling `concat` on a subclass constructor → TypeError (subclass does not appear in Table 70):
+- [ ] [25.6.1] Calling `fromList` on a subclass constructor → TypeError (subclass does not appear in Table 70):
   ```js
   class MyUint8 extends Uint8Array {}
-  MyUint8.concat([new Uint8Array([1, 2])]) // → TypeError
+  MyUint8.fromList([new Uint8Array([1, 2])]) // → TypeError
   // MyUint8 is a constructor but step 2 checks if `this` appears in the
   // Constructor column of Table 70. Only intrinsic constructors are listed.
   ```
@@ -1545,7 +1545,7 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
   class MyUint8 extends Uint8Array { constructor(...args) { super(...args); } }
   const a = new MyUint8([1, 2, 3]);
   // a has [[TypedArrayName]] === "Uint8Array"
-  const result = Uint8Array.concat([a]);
+  const result = Uint8Array.fromList([a]);
   result.length // → 3 (ValidateTypedArray passes, [[TypedArrayName]] matches)
   ```
 
@@ -1553,38 +1553,38 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
 
 ## 26. Missing Arguments and Default Behavior
 
-### 26.1 `%TypedArray%.concat` called with no arguments
+### 26.1 `%TypedArray%.fromList` called with no arguments
 
-- [ ] [26.1.1] `Uint8Array.concat()` → TypeError (`items` is `undefined`, which has no `Symbol.iterator`)
+- [ ] [26.1.1] `Uint8Array.fromList()` → TypeError (`items` is `undefined`, which has no `Symbol.iterator`)
 
-### 26.2 `ArrayBuffer.concat` called with no arguments
+### 26.2 `ArrayBuffer.fromList` called with no arguments
 
-- [ ] [26.2.1] `ArrayBuffer.concat()` → TypeError (`items` is `undefined`)
+- [ ] [26.2.1] `ArrayBuffer.fromList()` → TypeError (`items` is `undefined`)
 
-### 26.3 `SharedArrayBuffer.concat` called with no arguments
+### 26.3 `SharedArrayBuffer.fromList` called with no arguments
 
-- [ ] [26.3.1] `SharedArrayBuffer.concat()` → TypeError (`items` is `undefined`)
+- [ ] [26.3.1] `SharedArrayBuffer.fromList()` → TypeError (`items` is `undefined`)
 
 ### 26.4 Result buffer properties
 
-- [ ] [26.4.1] `%TypedArray%.concat` result buffer is not resizable:
+- [ ] [26.4.1] `%TypedArray%.fromList` result buffer is not resizable:
   ```js
-  const result = Uint8Array.concat([new Uint8Array([1, 2])]);
+  const result = Uint8Array.fromList([new Uint8Array([1, 2])]);
   result.buffer.resizable // → false
   ```
-- [ ] [26.4.2] `ArrayBuffer.concat` result is not resizable by default:
+- [ ] [26.4.2] `ArrayBuffer.fromList` result is not resizable by default:
   ```js
-  const result = ArrayBuffer.concat([new ArrayBuffer(4)]);
+  const result = ArrayBuffer.fromList([new ArrayBuffer(4)]);
   result.resizable // → false
   ```
-- [ ] [26.4.3] `ArrayBuffer.concat` result is not immutable by default:
+- [ ] [26.4.3] `ArrayBuffer.fromList` result is not immutable by default:
   ```js
-  const result = ArrayBuffer.concat([new ArrayBuffer(4)]);
+  const result = ArrayBuffer.fromList([new ArrayBuffer(4)]);
   result.immutable // → false (or undefined, depending on immutable proposal)
   ```
-- [ ] [26.4.4] `SharedArrayBuffer.concat` result is not growable by default:
+- [ ] [26.4.4] `SharedArrayBuffer.fromList` result is not growable by default:
   ```js
-  const result = SharedArrayBuffer.concat([new SharedArrayBuffer(4)]);
+  const result = SharedArrayBuffer.fromList([new SharedArrayBuffer(4)]);
   result.growable // → false
   ```
 
@@ -1592,16 +1592,16 @@ The spec algorithms read internal slots (`[[ArrayLength]]`, `[[ByteLength]]`, `[
 
 ## 27. Cross-Type Buffer Inputs
 
-All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffer. `ArrayBuffer.concat` and `SharedArrayBuffer.concat` accept both ArrayBuffer and SharedArrayBuffer directly. The return type is always determined by which method is called, not by the input types.
+All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffer. `ArrayBuffer.fromList` and `SharedArrayBuffer.fromList` accept both ArrayBuffer and SharedArrayBuffer directly. The return type is always determined by which method is called, not by the input types.
 
-### 27.1 `%TypedArray%.concat` — Items backed by SharedArrayBuffer
+### 27.1 `%TypedArray%.fromList` — Items backed by SharedArrayBuffer
 
 - [ ] [27.1.1] TypedArray over SharedArrayBuffer is a valid item (no TypeError):
   ```js
   const sab = new SharedArrayBuffer(4);
   new Uint8Array(sab).set([1, 2, 3, 4]);
   const u8 = new Uint8Array(sab);
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   result.length // → 4
   new Uint8Array(result) // → [1, 2, 3, 4] (subject to races if another agent writes concurrently)
   ```
@@ -1611,14 +1611,14 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   new Uint8Array(sab).set([1, 2, 3, 4]);
   const a = new Uint8Array(sab, 0, 2);
   const b = new Uint8Array(sab, 2, 2);
-  const result = Uint8Array.concat([a, b]);
+  const result = Uint8Array.fromList([a, b]);
   result.length // → 4
   ```
 - [ ] [27.1.3] Result buffer is a regular (non-shared) ArrayBuffer even when inputs are SharedArrayBuffer-backed:
   ```js
   const sab = new SharedArrayBuffer(4);
   const u8 = new Uint8Array(sab);
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
   result.buffer instanceof ArrayBuffer // → true
   result.buffer instanceof SharedArrayBuffer // → false
   ```
@@ -1628,18 +1628,18 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   new Uint8Array(ab).set([1, 2]);
   const sab = new SharedArrayBuffer(2);
   new Uint8Array(sab).set([3, 4]);
-  const result = Uint8Array.concat([new Uint8Array(ab), new Uint8Array(sab)]);
+  const result = Uint8Array.fromList([new Uint8Array(ab), new Uint8Array(sab)]);
   result.length // → 4
   new Uint8Array(result) // → [1, 2, 3, 4]
   ```
 
-### 27.2 `ArrayBuffer.concat` — SharedArrayBuffer and SAB-backed view inputs
+### 27.2 `ArrayBuffer.fromList` — SharedArrayBuffer and SAB-backed view inputs
 
 - [ ] [27.2.1] SharedArrayBuffer directly as item:
   ```js
   const sab = new SharedArrayBuffer(4);
   new Uint8Array(sab).set([10, 20, 30, 40]);
-  const result = ArrayBuffer.concat([sab]);
+  const result = ArrayBuffer.fromList([sab]);
   result.byteLength // → 4
   result instanceof ArrayBuffer // → true
   result instanceof SharedArrayBuffer // → false
@@ -1650,7 +1650,7 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   const sab = new SharedArrayBuffer(4);
   new Uint8Array(sab).set([10, 20, 30, 40]);
   const u8 = new Uint8Array(sab);
-  const result = ArrayBuffer.concat([u8]);
+  const result = ArrayBuffer.fromList([u8]);
   result.byteLength // → 4
   new Uint8Array(result) // → [10, 20, 30, 40]
   ```
@@ -1659,7 +1659,7 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   const sab = new SharedArrayBuffer(4);
   new Uint8Array(sab).set([10, 20, 30, 40]);
   const dv = new DataView(sab);
-  const result = ArrayBuffer.concat([dv]);
+  const result = ArrayBuffer.fromList([dv]);
   result.byteLength // → 4
   new Uint8Array(result) // → [10, 20, 30, 40]
   ```
@@ -1670,25 +1670,25 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   const sab = new SharedArrayBuffer(2);
   new Uint8Array(sab).set([3, 4]);
   const u8 = new Uint8Array([5, 6]);
-  const result = ArrayBuffer.concat([ab, sab, u8]);
+  const result = ArrayBuffer.fromList([ab, sab, u8]);
   result.byteLength // → 6
   new Uint8Array(result) // → [1, 2, 3, 4, 5, 6]
   ```
 - [ ] [27.2.5] Result is always an ArrayBuffer regardless of input types:
   ```js
   const sab = new SharedArrayBuffer(4);
-  const result = ArrayBuffer.concat([sab]);
+  const result = ArrayBuffer.fromList([sab]);
   result instanceof SharedArrayBuffer // → false
   result instanceof ArrayBuffer // → true
   ```
 
-### 27.3 `SharedArrayBuffer.concat` — ArrayBuffer and AB-backed view inputs
+### 27.3 `SharedArrayBuffer.fromList` — ArrayBuffer and AB-backed view inputs
 
 - [ ] [27.3.1] ArrayBuffer directly as item:
   ```js
   const ab = new ArrayBuffer(4);
   new Uint8Array(ab).set([10, 20, 30, 40]);
-  const result = SharedArrayBuffer.concat([ab]);
+  const result = SharedArrayBuffer.fromList([ab]);
   result.byteLength // → 4
   result instanceof SharedArrayBuffer // → true
   new Uint8Array(result) // → [10, 20, 30, 40]
@@ -1696,7 +1696,7 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
 - [ ] [27.3.2] TypedArray over ArrayBuffer as item:
   ```js
   const u8 = new Uint8Array([10, 20, 30, 40]);
-  const result = SharedArrayBuffer.concat([u8]);
+  const result = SharedArrayBuffer.fromList([u8]);
   result.byteLength // → 4
   result instanceof SharedArrayBuffer // → true
   new Uint8Array(result) // → [10, 20, 30, 40]
@@ -1706,7 +1706,7 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   const ab = new ArrayBuffer(4);
   new Uint8Array(ab).set([10, 20, 30, 40]);
   const dv = new DataView(ab);
-  const result = SharedArrayBuffer.concat([dv]);
+  const result = SharedArrayBuffer.fromList([dv]);
   result.byteLength // → 4
   result instanceof SharedArrayBuffer // → true
   ```
@@ -1717,7 +1717,7 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   const ab = new ArrayBuffer(2);
   new Uint8Array(ab).set([3, 4]);
   const u8 = new Uint8Array([5, 6]);
-  const result = SharedArrayBuffer.concat([sab, ab, u8]);
+  const result = SharedArrayBuffer.fromList([sab, ab, u8]);
   result.byteLength // → 6
   result instanceof SharedArrayBuffer // → true
   new Uint8Array(result) // → [1, 2, 3, 4, 5, 6]
@@ -1725,23 +1725,23 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
 - [ ] [27.3.5] Result is always a SharedArrayBuffer regardless of input types:
   ```js
   const ab = new ArrayBuffer(4);
-  const result = SharedArrayBuffer.concat([ab]);
+  const result = SharedArrayBuffer.fromList([ab]);
   result instanceof SharedArrayBuffer // → true
   ```
 - [ ] [27.3.6] Detached ArrayBuffer as direct item → TypeError:
   ```js
   const ab = new ArrayBuffer(4);
   ab.transfer();
-  SharedArrayBuffer.concat([ab]) // → TypeError
+  SharedArrayBuffer.fromList([ab]) // → TypeError
   ```
 
 ### 27.4 Concurrent modification of SharedArrayBuffer during copy
 
 `CopyDataBlockBytes` operates on the raw underlying data blocks without snapshotting. When a source is backed by a SharedArrayBuffer, another agent (Worker) may modify the data concurrently during the copy. The result may contain a mix of old and new values. These tests verify that concurrent writes do not cause crashes or undefined behavior, and that the result is a valid buffer containing *some* permutation of the written bytes.
 
-#### 27.4.1 `%TypedArray%.concat` — Concurrent write from a Worker
+#### 27.4.1 `%TypedArray%.fromList` — Concurrent write from a Worker
 
-- [ ] [27.4.1.1] Worker writes to SharedArrayBuffer while main thread calls `Uint8Array.concat`:
+- [ ] [27.4.1.1] Worker writes to SharedArrayBuffer while main thread calls `Uint8Array.fromList`:
   ```js
   // Setup: SharedArrayBuffer with known initial values
   const sab = new SharedArrayBuffer(1024);
@@ -1762,8 +1762,8 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   const worker = new Worker(URL.createObjectURL(blob));
   worker.postMessage(sab);
 
-  // Main thread: concat while worker is writing
-  const result = Uint8Array.concat([u8]);
+  // Main thread: fromList while worker is writing
+  const result = Uint8Array.fromList([u8]);
 
   // Assertions:
   result.length // → 1024
@@ -1776,20 +1776,20 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   worker.terminate();
   ```
 
-- [ ] [27.4.1.2] Result is a snapshot (modifications to SAB after concat don't affect result):
+- [ ] [27.4.1.2] Result is a snapshot (modifications to SAB after fromList don't affect result):
   ```js
   const sab = new SharedArrayBuffer(4);
   new Uint8Array(sab).set([1, 2, 3, 4]);
   const u8 = new Uint8Array(sab);
-  const result = Uint8Array.concat([u8]);
-  // Modify SAB after concat
+  const result = Uint8Array.fromList([u8]);
+  // Modify SAB after fromList
   new Uint8Array(sab).fill(0xFF);
   new Uint8Array(result) // → [1, 2, 3, 4] (result is independent of SAB)
   ```
 
-#### 27.4.2 `ArrayBuffer.concat` — Concurrent write from a Worker
+#### 27.4.2 `ArrayBuffer.fromList` — Concurrent write from a Worker
 
-- [ ] [27.4.2.1] Worker writes to SharedArrayBuffer while main thread calls `ArrayBuffer.concat` with a SAB input:
+- [ ] [27.4.2.1] Worker writes to SharedArrayBuffer while main thread calls `ArrayBuffer.fromList` with a SAB input:
   ```js
   const sab = new SharedArrayBuffer(1024);
   const u8 = new Uint8Array(sab);
@@ -1808,7 +1808,7 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   const worker = new Worker(URL.createObjectURL(blob));
   worker.postMessage(sab);
 
-  const result = ArrayBuffer.concat([sab]);
+  const result = ArrayBuffer.fromList([sab]);
 
   result.byteLength // → 1024
   result instanceof ArrayBuffer // → true
@@ -1821,7 +1821,7 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   worker.terminate();
   ```
 
-- [ ] [27.4.2.2] Worker writes to SharedArrayBuffer while main thread calls `ArrayBuffer.concat` with a DataView over SAB:
+- [ ] [27.4.2.2] Worker writes to SharedArrayBuffer while main thread calls `ArrayBuffer.fromList` with a DataView over SAB:
   ```js
   const sab = new SharedArrayBuffer(1024);
   new Uint8Array(sab).fill(0xAA);
@@ -1829,14 +1829,14 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
 
   // (Same worker pattern as 27.4.2.1)
   // ...
-  const result = ArrayBuffer.concat([dv]);
+  const result = ArrayBuffer.fromList([dv]);
   result.byteLength // → 1024
   // Each byte is either 0xAA or 0xBB
   ```
 
-#### 27.4.3 `SharedArrayBuffer.concat` — Concurrent write from a Worker
+#### 27.4.3 `SharedArrayBuffer.fromList` — Concurrent write from a Worker
 
-- [ ] [27.4.3.1] Worker writes to source SharedArrayBuffer while main thread calls `SharedArrayBuffer.concat`:
+- [ ] [27.4.3.1] Worker writes to source SharedArrayBuffer while main thread calls `SharedArrayBuffer.fromList`:
   ```js
   const sab = new SharedArrayBuffer(1024);
   new Uint8Array(sab).fill(0xAA);
@@ -1854,7 +1854,7 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   const worker = new Worker(URL.createObjectURL(blob));
   worker.postMessage(sab);
 
-  const result = SharedArrayBuffer.concat([sab]);
+  const result = SharedArrayBuffer.fromList([sab]);
 
   result.byteLength // → 1024
   result instanceof SharedArrayBuffer // → true
@@ -1893,7 +1893,7 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
   const worker = new Worker(URL.createObjectURL(blob));
   worker.postMessage(sab);
 
-  const result = Int32Array.concat([i32]);
+  const result = Int32Array.fromList([i32]);
   result.length // → 1
   // result[0] might be 0x11223344, 0xAABBCCDD, or a torn combination
   // The key assertion: no crash, result is a valid Int32Array of length 1
@@ -1902,11 +1902,11 @@ All three methods accept inputs backed by either ArrayBuffer or SharedArrayBuffe
 
 Note: Multi-byte tearing behavior is implementation-defined. The tests above assert structural validity (correct length, correct buffer type) rather than specific data values, since the exact bytes observed during a race are nondeterministic.
 
-### 27.5 Concurrent grow of growable SharedArrayBuffer during concat
+### 27.5 Concurrent grow of growable SharedArrayBuffer during fromList
 
 When a source is a growable SharedArrayBuffer (or a view over one), another agent may call `grow()` concurrently. The byte length is snapshotted during the validation loop with `~seq-cst~` ordering. The copy loop uses the snapshotted length from the `_sources_` record, not a fresh read. The underlying Shared Data Block is always allocated at `maxByteLength`, so `CopyDataBlockBytes` always reads from valid memory regardless of concurrent grows.
 
-#### 27.5.1 Direct growable SAB input — concurrent grow during concat
+#### 27.5.1 Direct growable SAB input — concurrent grow during fromList
 
 - [ ] [27.5.1.1] Another thread grows the SAB between validation and copy — result uses snapshotted length:
   ```js
@@ -1927,7 +1927,7 @@ When a source is a growable SharedArrayBuffer (or a view over one), another agen
   const worker = new Worker(URL.createObjectURL(blob));
   worker.postMessage(gsab);
 
-  const result = ArrayBuffer.concat([gsab]);
+  const result = ArrayBuffer.fromList([gsab]);
 
   // result.byteLength is either 4 (snapshotted before grow) or 512 (snapshotted after grow)
   // but is always one consistent value — never partially grown
@@ -1938,14 +1938,14 @@ When a source is a growable SharedArrayBuffer (or a view over one), another agen
   worker.terminate();
   ```
 
-- [ ] [27.5.1.2] Same test with `SharedArrayBuffer.concat`:
+- [ ] [27.5.1.2] Same test with `SharedArrayBuffer.fromList`:
   ```js
   const gsab = new SharedArrayBuffer(4, { maxByteLength: 1024 });
   new Uint8Array(gsab).set([1, 2, 3, 4]);
 
   // (Same worker pattern — grows gsab to 512)
   // ...
-  const result = SharedArrayBuffer.concat([gsab]);
+  const result = SharedArrayBuffer.fromList([gsab]);
 
   assert(result.byteLength === 4 || result.byteLength === 512);
   result instanceof SharedArrayBuffer // → true
@@ -1963,7 +1963,7 @@ When a source is a growable SharedArrayBuffer (or a view over one), another agen
 
   // Worker grows the buffer
   // ...
-  const result = Uint8Array.concat([u8]);
+  const result = Uint8Array.fromList([u8]);
 
   // result.length is snapshotted — either 4 (before grow) or grown size (after grow)
   // No crash, result is a valid Uint8Array
@@ -1983,7 +1983,7 @@ When a source is a growable SharedArrayBuffer (or a view over one), another agen
   // Worker grows gsab1 to 100 bytes
   // ...
 
-  const result = ArrayBuffer.concat([gsab1, gsab2]);
+  const result = ArrayBuffer.fromList([gsab1, gsab2]);
 
   // gsab1's snapshotted length is either 4 or 100 (depending on race)
   // gsab2's snapshotted length is always 4 (not grown)
@@ -2009,19 +2009,19 @@ Note: The exact length snapshotted depends on thread scheduling and is nondeterm
 
 ## 28. DataView with Detached Buffer
 
-- [ ] [28.1.1] DataView whose underlying buffer has been detached in `ArrayBuffer.concat` → TypeError:
+- [ ] [28.1.1] DataView whose underlying buffer has been detached in `ArrayBuffer.fromList` → TypeError:
   ```js
   const ab = new ArrayBuffer(4);
   const dv = new DataView(ab);
   ab.transfer();
-  ArrayBuffer.concat([dv]) // → TypeError (IsViewOutOfBounds returns true for detached buffers)
+  ArrayBuffer.fromList([dv]) // → TypeError (IsViewOutOfBounds returns true for detached buffers)
   ```
-- [ ] [28.1.2] DataView whose underlying buffer has been detached in `SharedArrayBuffer.concat` → TypeError:
+- [ ] [28.1.2] DataView whose underlying buffer has been detached in `SharedArrayBuffer.fromList` → TypeError:
   ```js
   const ab = new ArrayBuffer(4);
   const dv = new DataView(ab);
   ab.transfer();
-  SharedArrayBuffer.concat([dv]) // → TypeError
+  SharedArrayBuffer.fromList([dv]) // → TypeError
   ```
 
 ---
@@ -2030,12 +2030,12 @@ Note: The exact length snapshotted depends on thread scheduling and is nondeterm
 
 Note: Depends on the [Immutable ArrayBuffer proposal](https://github.com/tc39/proposal-immutable-arraybuffer).
 
-- [ ] [29.1.1] Immutable ArrayBuffer as direct item in `ArrayBuffer.concat`:
+- [ ] [29.1.1] Immutable ArrayBuffer as direct item in `ArrayBuffer.fromList`:
   ```js
   const ab = new ArrayBuffer(4);
   new Uint8Array(ab).set([1, 2, 3, 4]);
   const immutableAb = ab.transferToImmutable();
-  const result = ArrayBuffer.concat([immutableAb]);
+  const result = ArrayBuffer.fromList([immutableAb]);
   result.byteLength // → 4
   new Uint8Array(result) // → [1, 2, 3, 4]
   // immutableAb is not detached, not shared → accepted
@@ -2043,20 +2043,20 @@ Note: Depends on the [Immutable ArrayBuffer proposal](https://github.com/tc39/pr
 - [ ] [29.1.2] Immutable ArrayBuffer as input, mutable result by default:
   ```js
   const immutableAb = new ArrayBuffer(4).transferToImmutable();
-  const result = ArrayBuffer.concat([immutableAb]);
+  const result = ArrayBuffer.fromList([immutableAb]);
   result.immutable // → false (default, result is mutable)
   ```
-- [ ] [29.1.3] TypedArray view over immutable ArrayBuffer as item in `%TypedArray%.concat`:
+- [ ] [29.1.3] TypedArray view over immutable ArrayBuffer as item in `%TypedArray%.fromList`:
   ```js
   // Note: TypedArrays over immutable buffers are read-only but valid
   // ValidateTypedArray should pass (buffer is not detached)
   ```
-- [ ] [29.1.4] Immutable ArrayBuffer as direct item in `SharedArrayBuffer.concat`:
+- [ ] [29.1.4] Immutable ArrayBuffer as direct item in `SharedArrayBuffer.fromList`:
   ```js
   const ab = new ArrayBuffer(4);
   new Uint8Array(ab).set([1, 2, 3, 4]);
   const immutableAb = ab.transferToImmutable();
-  const result = SharedArrayBuffer.concat([immutableAb]);
+  const result = SharedArrayBuffer.fromList([immutableAb]);
   result.byteLength // → 4
   result instanceof SharedArrayBuffer // → true
   new Uint8Array(result) // → [1, 2, 3, 4]
@@ -2066,7 +2066,7 @@ Note: Depends on the [Immutable ArrayBuffer proposal](https://github.com/tc39/pr
 
 ## 30. Options Property Access Order
 
-### 30.1 `ArrayBuffer.concat` options access order
+### 30.1 `ArrayBuffer.fromList` options access order
 
 The spec reads options properties in order: `length` (step 5a), `resizable` (step 5b), `immutable` (step 5c). Observable via getters.
 
@@ -2078,7 +2078,7 @@ The spec reads options properties in order: `length` (step 5a), `resizable` (ste
     get resizable() { order.push('resizable'); return false; },
     get immutable() { order.push('immutable'); return false; },
   };
-  ArrayBuffer.concat([], opts);
+  ArrayBuffer.fromList([], opts);
   order // → ['length', 'resizable', 'immutable']
   ```
 - [ ] [30.1.2] If `length` getter throws, `resizable` and `immutable` are never accessed:
@@ -2089,7 +2089,7 @@ The spec reads options properties in order: `length` (step 5a), `resizable` (ste
     get resizable() { order.push('resizable'); return false; },
     get immutable() { order.push('immutable'); return false; },
   };
-  try { ArrayBuffer.concat([], opts); } catch(e) {}
+  try { ArrayBuffer.fromList([], opts); } catch(e) {}
   order // → [] (resizable and immutable never read)
   ```
 - [ ] [30.1.3] If `resizable` getter throws, `immutable` is never accessed:
@@ -2100,11 +2100,11 @@ The spec reads options properties in order: `length` (step 5a), `resizable` (ste
     get resizable() { throw new Error('resizable'); },
     get immutable() { order.push('immutable'); return false; },
   };
-  try { ArrayBuffer.concat([], opts); } catch(e) {}
+  try { ArrayBuffer.fromList([], opts); } catch(e) {}
   order // → ['length'] (immutable never read)
   ```
 
-### 30.2 `SharedArrayBuffer.concat` options access order
+### 30.2 `SharedArrayBuffer.fromList` options access order
 
 The spec reads options properties in order: `length` (step 5a), `growable` (step 5b). Observable via getters.
 
@@ -2115,7 +2115,7 @@ The spec reads options properties in order: `length` (step 5a), `growable` (step
     get length() { order.push('length'); return undefined; },
     get growable() { order.push('growable'); return false; },
   };
-  SharedArrayBuffer.concat([], opts);
+  SharedArrayBuffer.fromList([], opts);
   order // → ['length', 'growable']
   ```
 - [ ] [30.2.2] If `length` getter throws, `growable` is never accessed:
@@ -2125,7 +2125,7 @@ The spec reads options properties in order: `length` (step 5a), `growable` (step
     get length() { throw new Error('length'); },
     get growable() { order.push('growable'); return false; },
   };
-  try { SharedArrayBuffer.concat([], opts); } catch(e) {}
+  try { SharedArrayBuffer.fromList([], opts); } catch(e) {}
   order // → [] (growable never read)
   ```
 
@@ -2135,9 +2135,9 @@ The spec reads options properties in order: `length` (step 5a), `growable` (step
 
 ### 31.1 `Number.MAX_SAFE_INTEGER` as length (exactly 2^53 - 1)
 
-- [ ] [31.1.1] `Uint8Array.concat([], Number.MAX_SAFE_INTEGER)` → accepted (does not throw RangeError from overflow check); will likely throw from `AllocateTypedArrayBuffer` due to implementation memory limits
-- [ ] [31.1.2] `ArrayBuffer.concat([], { length: Number.MAX_SAFE_INTEGER })` → accepted (does not throw from overflow check); will likely throw from `AllocateArrayBuffer`
-- [ ] [31.1.3] `SharedArrayBuffer.concat([], { length: Number.MAX_SAFE_INTEGER })` → accepted (does not throw from overflow check); will likely throw from `AllocateSharedArrayBuffer`
+- [ ] [31.1.1] `Uint8Array.fromList([], Number.MAX_SAFE_INTEGER)` → accepted (does not throw RangeError from overflow check); will likely throw from `AllocateTypedArrayBuffer` due to implementation memory limits
+- [ ] [31.1.2] `ArrayBuffer.fromList([], { length: Number.MAX_SAFE_INTEGER })` → accepted (does not throw from overflow check); will likely throw from `AllocateArrayBuffer`
+- [ ] [31.1.3] `SharedArrayBuffer.fromList([], { length: Number.MAX_SAFE_INTEGER })` → accepted (does not throw from overflow check); will likely throw from `AllocateSharedArrayBuffer`
 
 ### 31.2 Overflow check with explicit length provided
 
@@ -2150,24 +2150,24 @@ The spec reads options properties in order: `length` (step 5a), `growable` (step
 
 ### 31.3 `length` of exactly 0 with items
 
-- [ ] [31.3.1] `Uint8Array.concat([new Uint8Array([1, 2, 3])], 0)` → empty TypedArray, items still validated:
+- [ ] [31.3.1] `Uint8Array.fromList([new Uint8Array([1, 2, 3])], 0)` → empty TypedArray, items still validated:
   ```js
   // Even though the result is empty, all items are validated (ValidateTypedArray, type check)
-  Uint8Array.concat([new Int16Array([1])], 0) // → TypeError (type mismatch, not silently skipped)
+  Uint8Array.fromList([new Int16Array([1])], 0) // → TypeError (type mismatch, not silently skipped)
   ```
-- [ ] [31.3.2] `ArrayBuffer.concat([new SharedArrayBuffer(4)], { length: 0 })` → empty ArrayBuffer (SharedArrayBuffer accepted, result truncated to 0 bytes)
+- [ ] [31.3.2] `ArrayBuffer.fromList([new SharedArrayBuffer(4)], { length: 0 })` → empty ArrayBuffer (SharedArrayBuffer accepted, result truncated to 0 bytes)
 
 ---
 
-## 32. `SharedArrayBuffer.concat` — Items Validation
+## 32. `SharedArrayBuffer.fromList` — Items Validation
 
 ### 32.1 Items is not iterable
 
-- [ ] [32.1.1] `SharedArrayBuffer.concat(undefined)` → TypeError
-- [ ] [32.1.2] `SharedArrayBuffer.concat(null)` → TypeError
-- [ ] [32.1.3] `SharedArrayBuffer.concat(42)` → TypeError
-- [ ] [32.1.4] `SharedArrayBuffer.concat({})` → TypeError
-- [ ] [32.1.5] `SharedArrayBuffer.concat({ [Symbol.iterator]: null })` → TypeError (`GetMethod` returns *undefined* when property is *null*)
+- [ ] [32.1.1] `SharedArrayBuffer.fromList(undefined)` → TypeError
+- [ ] [32.1.2] `SharedArrayBuffer.fromList(null)` → TypeError
+- [ ] [32.1.3] `SharedArrayBuffer.fromList(42)` → TypeError
+- [ ] [32.1.4] `SharedArrayBuffer.fromList({})` → TypeError
+- [ ] [32.1.5] `SharedArrayBuffer.fromList({ [Symbol.iterator]: null })` → TypeError (`GetMethod` returns *undefined* when property is *null*)
 
 ### 32.2 Items iterable throws during iteration
 
@@ -2176,12 +2176,12 @@ The spec reads options properties in order: `length` (step 5a), `growable` (step
 
 ### 32.3 Item is not an ArrayBuffer, SharedArrayBuffer, TypedArray, or DataView
 
-- [ ] [32.3.1] `SharedArrayBuffer.concat([42])` → TypeError
-- [ ] [32.3.2] `SharedArrayBuffer.concat([{}])` → TypeError
-- [ ] [32.3.3] `SharedArrayBuffer.concat(['string'])` → TypeError
-- [ ] [32.3.4] `SharedArrayBuffer.concat([null])` → TypeError
-- [ ] [32.3.5] `SharedArrayBuffer.concat([undefined])` → TypeError
-- [ ] [32.3.6] `SharedArrayBuffer.concat([[1, 2, 3]])` → TypeError (plain Array)
+- [ ] [32.3.1] `SharedArrayBuffer.fromList([42])` → TypeError
+- [ ] [32.3.2] `SharedArrayBuffer.fromList([{}])` → TypeError
+- [ ] [32.3.3] `SharedArrayBuffer.fromList(['string'])` → TypeError
+- [ ] [32.3.4] `SharedArrayBuffer.fromList([null])` → TypeError
+- [ ] [32.3.5] `SharedArrayBuffer.fromList([undefined])` → TypeError
+- [ ] [32.3.6] `SharedArrayBuffer.fromList([[1, 2, 3]])` → TypeError (plain Array)
 
 ### 32.4 Item is a detached ArrayBuffer
 
@@ -2189,7 +2189,7 @@ The spec reads options properties in order: `length` (step 5a), `growable` (step
   ```js
   const ab = new ArrayBuffer(4);
   ab.transfer();
-  SharedArrayBuffer.concat([ab]) // → TypeError
+  SharedArrayBuffer.fromList([ab]) // → TypeError
   ```
 
 ### 32.5 Item is a TypedArray with a detached buffer
@@ -2202,82 +2202,82 @@ The spec reads options properties in order: `length` (step 5a), `growable` (step
 
 ### 32.7 Mixed valid item types
 
-- [ ] [32.7.1] `SharedArrayBuffer.concat([new SharedArrayBuffer(2), new Uint8Array([1, 2]), new DataView(new ArrayBuffer(3))])` → SharedArrayBuffer of byteLength 7
-- [ ] [32.7.2] `SharedArrayBuffer.concat([new ArrayBuffer(2), new SharedArrayBuffer(2)])` → SharedArrayBuffer of byteLength 4
+- [ ] [32.7.1] `SharedArrayBuffer.fromList([new SharedArrayBuffer(2), new Uint8Array([1, 2]), new DataView(new ArrayBuffer(3))])` → SharedArrayBuffer of byteLength 7
+- [ ] [32.7.2] `SharedArrayBuffer.fromList([new ArrayBuffer(2), new SharedArrayBuffer(2)])` → SharedArrayBuffer of byteLength 4
 - [ ] [32.7.3] First item valid, second item invalid → TypeError on second item
 
 ---
 
-## 33. `SharedArrayBuffer.concat` — Options Validation
+## 33. `SharedArrayBuffer.fromList` — Options Validation
 
 ### 33.1 Options is `undefined` or not provided
 
-- [ ] [33.1.1] `SharedArrayBuffer.concat([new SharedArrayBuffer(4)])` → works, no options
-- [ ] [33.1.2] `SharedArrayBuffer.concat([new SharedArrayBuffer(4)], undefined)` → works, same as no options
+- [ ] [33.1.1] `SharedArrayBuffer.fromList([new SharedArrayBuffer(4)])` → works, no options
+- [ ] [33.1.2] `SharedArrayBuffer.fromList([new SharedArrayBuffer(4)], undefined)` → works, same as no options
 
 ### 33.2 Options is not an object
 
-- [ ] [33.2.1] `SharedArrayBuffer.concat([], 42)` → TypeError from `GetOptionsObject`
-- [ ] [33.2.2] `SharedArrayBuffer.concat([], 'string')` → TypeError
-- [ ] [33.2.3] `SharedArrayBuffer.concat([], true)` → TypeError
-- [ ] [33.2.4] `SharedArrayBuffer.concat([], null)` → TypeError (*null* is not *undefined* and not an Object)
+- [ ] [33.2.1] `SharedArrayBuffer.fromList([], 42)` → TypeError from `GetOptionsObject`
+- [ ] [33.2.2] `SharedArrayBuffer.fromList([], 'string')` → TypeError
+- [ ] [33.2.3] `SharedArrayBuffer.fromList([], true)` → TypeError
+- [ ] [33.2.4] `SharedArrayBuffer.fromList([], null)` → TypeError (*null* is not *undefined* and not an Object)
 
 ### 33.3 Length option validation
 
 #### 33.3.1 Non-Number length → TypeError
 
-- [ ] [33.3.1.1] `SharedArrayBuffer.concat([], { length: 'hello' })` → TypeError
-- [ ] [33.3.1.2] `SharedArrayBuffer.concat([], { length: {} })` → TypeError
-- [ ] [33.3.1.3] `SharedArrayBuffer.concat([], { length: true })` → TypeError
-- [ ] [33.3.1.4] `SharedArrayBuffer.concat([], { length: Symbol() })` → TypeError
-- [ ] [33.3.1.5] `SharedArrayBuffer.concat([], { length: 1n })` → TypeError
+- [ ] [33.3.1.1] `SharedArrayBuffer.fromList([], { length: 'hello' })` → TypeError
+- [ ] [33.3.1.2] `SharedArrayBuffer.fromList([], { length: {} })` → TypeError
+- [ ] [33.3.1.3] `SharedArrayBuffer.fromList([], { length: true })` → TypeError
+- [ ] [33.3.1.4] `SharedArrayBuffer.fromList([], { length: Symbol() })` → TypeError
+- [ ] [33.3.1.5] `SharedArrayBuffer.fromList([], { length: 1n })` → TypeError
 
 #### 33.3.2 NaN / non-integral / Infinity → RangeError
 
-- [ ] [33.3.2.1] `SharedArrayBuffer.concat([], { length: NaN })` → RangeError
-- [ ] [33.3.2.2] `SharedArrayBuffer.concat([], { length: 1.5 })` → RangeError
-- [ ] [33.3.2.3] `SharedArrayBuffer.concat([], { length: Infinity })` → RangeError
-- [ ] [33.3.2.4] `SharedArrayBuffer.concat([], { length: -Infinity })` → RangeError
+- [ ] [33.3.2.1] `SharedArrayBuffer.fromList([], { length: NaN })` → RangeError
+- [ ] [33.3.2.2] `SharedArrayBuffer.fromList([], { length: 1.5 })` → RangeError
+- [ ] [33.3.2.3] `SharedArrayBuffer.fromList([], { length: Infinity })` → RangeError
+- [ ] [33.3.2.4] `SharedArrayBuffer.fromList([], { length: -Infinity })` → RangeError
 
 #### 33.3.3 Negative length → RangeError
 
-- [ ] [33.3.3.1] `SharedArrayBuffer.concat([], { length: -1 })` → RangeError
-- [ ] [33.3.3.2] `SharedArrayBuffer.concat([], { length: -100 })` → RangeError
+- [ ] [33.3.3.1] `SharedArrayBuffer.fromList([], { length: -1 })` → RangeError
+- [ ] [33.3.3.2] `SharedArrayBuffer.fromList([], { length: -100 })` → RangeError
 
 #### 33.3.4 Length exceeds 2^53 - 1 → RangeError
 
-- [ ] [33.3.4.1] `SharedArrayBuffer.concat([], { length: 2 ** 53 })` → RangeError
-- [ ] [33.3.4.2] `SharedArrayBuffer.concat([], { length: Number.MAX_SAFE_INTEGER + 1 })` → RangeError
+- [ ] [33.3.4.1] `SharedArrayBuffer.fromList([], { length: 2 ** 53 })` → RangeError
+- [ ] [33.3.4.2] `SharedArrayBuffer.fromList([], { length: Number.MAX_SAFE_INTEGER + 1 })` → RangeError
 
 #### 33.3.5 Length is -0 (treated as 0)
 
-- [ ] [33.3.5.1] `SharedArrayBuffer.concat([new SharedArrayBuffer(4)], { length: -0 })` → SharedArrayBuffer of byteLength 0
+- [ ] [33.3.5.1] `SharedArrayBuffer.fromList([new SharedArrayBuffer(4)], { length: -0 })` → SharedArrayBuffer of byteLength 0
 
 #### 33.3.6 Length is `undefined` (same as not provided)
 
-- [ ] [33.3.6.1] `SharedArrayBuffer.concat([new SharedArrayBuffer(4)], { length: undefined })` → byteLength 4 (defaults to total)
+- [ ] [33.3.6.1] `SharedArrayBuffer.fromList([new SharedArrayBuffer(4)], { length: undefined })` → byteLength 4 (defaults to total)
 
 ### 33.4 Growable option
 
-- [ ] [33.4.1] `SharedArrayBuffer.concat([], { growable: true })` → result is growable
-- [ ] [33.4.2] `SharedArrayBuffer.concat([], { growable: false })` → result is not growable (default behavior)
+- [ ] [33.4.1] `SharedArrayBuffer.fromList([], { growable: true })` → result is growable
+- [ ] [33.4.2] `SharedArrayBuffer.fromList([], { growable: false })` → result is not growable (default behavior)
 
 ### 33.5 Growable is coerced via `ToBoolean`
 
-- [ ] [33.5.1] `SharedArrayBuffer.concat([], { growable: 1 })` → result is growable (truthy)
-- [ ] [33.5.2] `SharedArrayBuffer.concat([], { growable: 0 })` → result is not growable (falsy)
-- [ ] [33.5.3] `SharedArrayBuffer.concat([], { growable: '' })` → result is not growable (falsy)
-- [ ] [33.5.4] `SharedArrayBuffer.concat([], { growable: 'yes' })` → result is growable (truthy)
-- [ ] [33.5.5] `SharedArrayBuffer.concat([], { growable: null })` → result is not growable (falsy)
-- [ ] [33.5.6] `SharedArrayBuffer.concat([], { growable: undefined })` → result is not growable (falsy)
+- [ ] [33.5.1] `SharedArrayBuffer.fromList([], { growable: 1 })` → result is growable (truthy)
+- [ ] [33.5.2] `SharedArrayBuffer.fromList([], { growable: 0 })` → result is not growable (falsy)
+- [ ] [33.5.3] `SharedArrayBuffer.fromList([], { growable: '' })` → result is not growable (falsy)
+- [ ] [33.5.4] `SharedArrayBuffer.fromList([], { growable: 'yes' })` → result is growable (truthy)
+- [ ] [33.5.5] `SharedArrayBuffer.fromList([], { growable: null })` → result is not growable (falsy)
+- [ ] [33.5.6] `SharedArrayBuffer.fromList([], { growable: undefined })` → result is not growable (falsy)
 
 ### 33.6 No `immutable` option
 
-- [ ] [33.6.1] `SharedArrayBuffer.concat([], { immutable: true })` → `immutable` option is ignored (SharedArrayBuffer has no immutable concept); result is a normal SharedArrayBuffer
+- [ ] [33.6.1] `SharedArrayBuffer.fromList([], { immutable: true })` → `immutable` option is ignored (SharedArrayBuffer has no immutable concept); result is a normal SharedArrayBuffer
 
 ---
 
-## 34. `SharedArrayBuffer.concat` — Overflow Check on `totalByteLength`
+## 34. `SharedArrayBuffer.fromList` — Overflow Check on `totalByteLength`
 
 ### 34.1 Total byte length exceeds 2^53 - 1
 
@@ -2289,7 +2289,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
 
 ---
 
-## 35. `SharedArrayBuffer.concat` — Basic Concatenation
+## 35. `SharedArrayBuffer.fromList` — Basic Concatenation
 
 ### 35.1 SharedArrayBuffer inputs
 
@@ -2299,7 +2299,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   new Uint8Array(sab1).set([1, 2, 3, 4]);
   const sab2 = new SharedArrayBuffer(4);
   new Uint8Array(sab2).set([5, 6, 7, 8]);
-  const result = SharedArrayBuffer.concat([sab1, sab2]);
+  const result = SharedArrayBuffer.fromList([sab1, sab2]);
   result.byteLength // → 8
   result instanceof SharedArrayBuffer // → true
   new Uint8Array(result) // → [1, 2, 3, 4, 5, 6, 7, 8]
@@ -2313,7 +2313,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   ```js
   const ab = new ArrayBuffer(4);
   new Uint8Array(ab).set([1, 2, 3, 4]);
-  const result = SharedArrayBuffer.concat([ab]);
+  const result = SharedArrayBuffer.fromList([ab]);
   result.byteLength // → 4
   result instanceof SharedArrayBuffer // → true
   new Uint8Array(result) // → [1, 2, 3, 4]
@@ -2324,7 +2324,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
 - [ ] [35.3.1] Full-buffer TypedArray:
   ```js
   const u8 = new Uint8Array([1, 2, 3, 4]);
-  const result = SharedArrayBuffer.concat([u8]);
+  const result = SharedArrayBuffer.fromList([u8]);
   result.byteLength // → 4
   result instanceof SharedArrayBuffer // → true
   ```
@@ -2333,14 +2333,14 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   const ab = new ArrayBuffer(8);
   new Uint8Array(ab).set([1, 2, 3, 4, 5, 6, 7, 8]);
   const view = new Uint8Array(ab, 2, 3); // views bytes [3, 4, 5]
-  const result = SharedArrayBuffer.concat([view]);
+  const result = SharedArrayBuffer.fromList([view]);
   result.byteLength // → 3
   new Uint8Array(result) // → [3, 4, 5]
   ```
 - [ ] [35.3.3] Multi-byte element TypedArray:
   ```js
   const i32 = new Int32Array([1, 2]); // 8 bytes
-  const result = SharedArrayBuffer.concat([i32]);
+  const result = SharedArrayBuffer.fromList([i32]);
   result.byteLength // → 8
   ```
 
@@ -2351,7 +2351,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   const ab = new ArrayBuffer(4);
   new Uint8Array(ab).set([1, 2, 3, 4]);
   const dv = new DataView(ab);
-  const result = SharedArrayBuffer.concat([dv]);
+  const result = SharedArrayBuffer.fromList([dv]);
   result.byteLength // → 4
   result instanceof SharedArrayBuffer // → true
   ```
@@ -2360,7 +2360,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   const ab = new ArrayBuffer(8);
   new Uint8Array(ab).set([1, 2, 3, 4, 5, 6, 7, 8]);
   const dv = new DataView(ab, 2, 3);
-  const result = SharedArrayBuffer.concat([dv]);
+  const result = SharedArrayBuffer.fromList([dv]);
   result.byteLength // → 3
   new Uint8Array(result) // → [3, 4, 5]
   ```
@@ -2376,7 +2376,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   const u8 = new Uint8Array([5, 6]);
   const dv = new DataView(new ArrayBuffer(2));
   new Uint8Array(dv.buffer).set([7, 8]);
-  const result = SharedArrayBuffer.concat([sab, ab, u8, dv]);
+  const result = SharedArrayBuffer.fromList([sab, ab, u8, dv]);
   result.byteLength // → 8
   result instanceof SharedArrayBuffer // → true
   new Uint8Array(result) // → [1, 2, 3, 4, 5, 6, 7, 8]
@@ -2384,77 +2384,77 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
 
 ### 35.6 Empty inputs
 
-- [ ] [35.6.1] `SharedArrayBuffer.concat([])` → SharedArrayBuffer of byteLength 0
-- [ ] [35.6.2] `SharedArrayBuffer.concat([new SharedArrayBuffer(0)])` → SharedArrayBuffer of byteLength 0
-- [ ] [35.6.3] `SharedArrayBuffer.concat([new SharedArrayBuffer(0), new SharedArrayBuffer(0)])` → SharedArrayBuffer of byteLength 0
+- [ ] [35.6.1] `SharedArrayBuffer.fromList([])` → SharedArrayBuffer of byteLength 0
+- [ ] [35.6.2] `SharedArrayBuffer.fromList([new SharedArrayBuffer(0)])` → SharedArrayBuffer of byteLength 0
+- [ ] [35.6.3] `SharedArrayBuffer.fromList([new SharedArrayBuffer(0), new SharedArrayBuffer(0)])` → SharedArrayBuffer of byteLength 0
 
 ### 35.7 Result is always a new SharedArrayBuffer
 
 - [ ] [35.7.1] Result is not the same object as any input:
   ```js
   const sab = new SharedArrayBuffer(4);
-  const result = SharedArrayBuffer.concat([sab]);
+  const result = SharedArrayBuffer.fromList([sab]);
   result !== sab // → true
   ```
 
 ---
 
-## 36. `SharedArrayBuffer.concat` — Truncation and Zero-Fill
+## 36. `SharedArrayBuffer.fromList` — Truncation and Zero-Fill
 
 ### 36.1 Truncation (length < totalByteLength)
 
-- [ ] [36.1.1] `SharedArrayBuffer.concat([new SharedArrayBuffer(8)], { length: 4 })` → byteLength 4
+- [ ] [36.1.1] `SharedArrayBuffer.fromList([new SharedArrayBuffer(8)], { length: 4 })` → byteLength 4
 - [ ] [36.1.2] Truncation mid-second-item:
   ```js
   const sab1 = new SharedArrayBuffer(4);
   new Uint8Array(sab1).set([1, 2, 3, 4]);
   const sab2 = new SharedArrayBuffer(4);
   new Uint8Array(sab2).set([5, 6, 7, 8]);
-  const result = SharedArrayBuffer.concat([sab1, sab2], { length: 6 });
+  const result = SharedArrayBuffer.fromList([sab1, sab2], { length: 6 });
   new Uint8Array(result) // → [1, 2, 3, 4, 5, 6]
   ```
-- [ ] [36.1.3] Truncation to 0: `SharedArrayBuffer.concat([new SharedArrayBuffer(4)], { length: 0 })` → byteLength 0
+- [ ] [36.1.3] Truncation to 0: `SharedArrayBuffer.fromList([new SharedArrayBuffer(4)], { length: 0 })` → byteLength 0
 
 ### 36.2 Zero-fill (length > totalByteLength)
 
-- [ ] [36.2.1] `SharedArrayBuffer.concat([new SharedArrayBuffer(4)], { length: 8 })` → byteLength 8, last 4 bytes are 0
-- [ ] [36.2.2] `SharedArrayBuffer.concat([], { length: 4 })` → byteLength 4, all bytes 0
+- [ ] [36.2.1] `SharedArrayBuffer.fromList([new SharedArrayBuffer(4)], { length: 8 })` → byteLength 8, last 4 bytes are 0
+- [ ] [36.2.2] `SharedArrayBuffer.fromList([], { length: 4 })` → byteLength 4, all bytes 0
 - [ ] [36.2.3] Verify zero-fill bytes are actually 0:
   ```js
   const sab = new SharedArrayBuffer(2);
   new Uint8Array(sab).set([0xFF, 0xFF]);
-  const result = SharedArrayBuffer.concat([sab], { length: 4 });
+  const result = SharedArrayBuffer.fromList([sab], { length: 4 });
   const u8 = new Uint8Array(result);
   // u8[0] === 0xFF, u8[1] === 0xFF, u8[2] === 0, u8[3] === 0
   ```
 
 ### 36.3 Exact length
 
-- [ ] [36.3.1] `SharedArrayBuffer.concat([new SharedArrayBuffer(4)], { length: 4 })` → byteLength 4 (same as no length)
+- [ ] [36.3.1] `SharedArrayBuffer.fromList([new SharedArrayBuffer(4)], { length: 4 })` → byteLength 4 (same as no length)
 
 ---
 
-## 37. `SharedArrayBuffer.concat` — Growable Option
+## 37. `SharedArrayBuffer.fromList` — Growable Option
 
 ### 37.1 Basic growable result
 
 - [ ] [37.1.1] Growable with explicit length:
   ```js
-  const result = SharedArrayBuffer.concat([new SharedArrayBuffer(4)], { growable: true, length: 16 });
+  const result = SharedArrayBuffer.fromList([new SharedArrayBuffer(4)], { growable: true, length: 16 });
   result.growable // → true
   result.byteLength // → 4 (actual data)
   result.maxByteLength // → 16
   ```
 - [ ] [37.1.2] Growable result can be grown:
   ```js
-  const result = SharedArrayBuffer.concat([new SharedArrayBuffer(4)], { growable: true, length: 16 });
+  const result = SharedArrayBuffer.fromList([new SharedArrayBuffer(4)], { growable: true, length: 16 });
   result.grow(8);
   result.byteLength // → 8
   ```
 
 ### 37.2 Growable without explicit length (maxByteLength = totalByteLength)
 
-- [ ] [37.2.1] `SharedArrayBuffer.concat([new SharedArrayBuffer(4)], { growable: true })` → `byteLength === 4`, `maxByteLength === 4` (buffer already at max)
+- [ ] [37.2.1] `SharedArrayBuffer.fromList([new SharedArrayBuffer(4)], { growable: true })` → `byteLength === 4`, `maxByteLength === 4` (buffer already at max)
 
 ### 37.3 Growable with length less than totalByteLength
 
@@ -2462,7 +2462,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   ```js
   const sab1 = new SharedArrayBuffer(4);
   const sab2 = new SharedArrayBuffer(4);
-  const result = SharedArrayBuffer.concat([sab1, sab2], { growable: true, length: 6 });
+  const result = SharedArrayBuffer.fromList([sab1, sab2], { growable: true, length: 6 });
   result.byteLength // → 6 (clamped: min(8, 6))
   result.maxByteLength // → 6
   ```
@@ -2471,7 +2471,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
 
 - [ ] [37.4.1] `byteLength` equals total data, `maxByteLength` equals `length`:
   ```js
-  const result = SharedArrayBuffer.concat([new SharedArrayBuffer(4)], { growable: true, length: 32 });
+  const result = SharedArrayBuffer.fromList([new SharedArrayBuffer(4)], { growable: true, length: 32 });
   result.byteLength // → 4 (actual data)
   result.maxByteLength // → 32 (room to grow)
   ```
@@ -2482,13 +2482,13 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   ```js
   const sab = new SharedArrayBuffer(4);
   new Uint8Array(sab).set([1, 2, 3, 4]);
-  const result = SharedArrayBuffer.concat([sab], { growable: true, length: 16 });
+  const result = SharedArrayBuffer.fromList([sab], { growable: true, length: 16 });
   new Uint8Array(result, 0, 4) // → [1, 2, 3, 4]
   ```
 
 ---
 
-## 38. `SharedArrayBuffer.concat` — Growable SharedArrayBuffer Inputs
+## 38. `SharedArrayBuffer.fromList` — Growable SharedArrayBuffer Inputs
 
 ### 38.1 Only current byteLength is copied (not maxByteLength)
 
@@ -2496,7 +2496,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   ```js
   const gsab = new SharedArrayBuffer(4, { maxByteLength: 64 });
   new Uint8Array(gsab).set([1, 2, 3, 4]);
-  const result = SharedArrayBuffer.concat([gsab]);
+  const result = SharedArrayBuffer.fromList([gsab]);
   result.byteLength // → 4 (not 64)
   new Uint8Array(result) // → [1, 2, 3, 4]
   ```
@@ -2506,7 +2506,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   const gsab2 = new SharedArrayBuffer(2, { maxByteLength: 200 });
   new Uint8Array(gsab1).set([1, 2, 3]);
   new Uint8Array(gsab2).set([4, 5]);
-  const result = SharedArrayBuffer.concat([gsab1, gsab2]);
+  const result = SharedArrayBuffer.fromList([gsab1, gsab2]);
   result.byteLength // → 5 (not 300)
   new Uint8Array(result) // → [1, 2, 3, 4, 5]
   ```
@@ -2518,7 +2518,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   const gsab = new SharedArrayBuffer(4, { maxByteLength: 32 });
   new Uint8Array(gsab).set([1, 2, 3, 4]);
   gsab.grow(8);
-  const result = SharedArrayBuffer.concat([gsab]);
+  const result = SharedArrayBuffer.fromList([gsab]);
   result.byteLength // → 8
   new Uint8Array(result) // → [1, 2, 3, 4, 0, 0, 0, 0]
   ```
@@ -2530,7 +2530,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   const gsab = new SharedArrayBuffer(4, { maxByteLength: 64 });
   new Uint8Array(gsab).set([10, 20, 30, 40]);
   const u8 = new Uint8Array(gsab); // auto-length
-  const result = SharedArrayBuffer.concat([u8]);
+  const result = SharedArrayBuffer.fromList([u8]);
   result.byteLength // → 4 (not 64)
   ```
 - [ ] [38.3.2] Fixed-length TypedArray over growable SharedArrayBuffer:
@@ -2538,19 +2538,19 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   const gsab = new SharedArrayBuffer(16, { maxByteLength: 64 });
   const u8 = new Uint8Array(gsab, 0, 4); // fixed-length: 4 elements
   new Uint8Array(gsab).set([1, 2, 3, 4]);
-  const result = SharedArrayBuffer.concat([u8]);
+  const result = SharedArrayBuffer.fromList([u8]);
   result.byteLength // → 4
   ```
 
 ---
 
-## 39. `SharedArrayBuffer.concat` — Copy Loop Edge Cases
+## 39. `SharedArrayBuffer.fromList` — Copy Loop Edge Cases
 
 ### 39.1 Short-circuit when result is full
 
 - [ ] [39.1.1] With `length: 0`, no bytes are copied:
   ```js
-  const result = SharedArrayBuffer.concat([new SharedArrayBuffer(4)], { length: 0 });
+  const result = SharedArrayBuffer.fromList([new SharedArrayBuffer(4)], { length: 0 });
   result.byteLength // → 0
   ```
 - [ ] [39.1.2] With `length: 2` and items totalling 8 bytes, only the first 2 bytes are in the result
@@ -2565,17 +2565,17 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   new Uint8Array(sab2).set([4, 5, 6]);
   const sab3 = new SharedArrayBuffer(3);
   new Uint8Array(sab3).set([7, 8, 9]);
-  const result = SharedArrayBuffer.concat([sab1, sab2, sab3], { length: 5 });
+  const result = SharedArrayBuffer.fromList([sab1, sab2, sab3], { length: 5 });
   new Uint8Array(result) // → [1, 2, 3, 4, 5]
   ```
 
 ### 39.3 Zero-length items in the mix
 
-- [ ] [39.3.1] `SharedArrayBuffer.concat([new SharedArrayBuffer(0), new SharedArrayBuffer(4), new SharedArrayBuffer(0)])` → byteLength 4
+- [ ] [39.3.1] `SharedArrayBuffer.fromList([new SharedArrayBuffer(0), new SharedArrayBuffer(4), new SharedArrayBuffer(0)])` → byteLength 4
 
 ---
 
-## 40. `SharedArrayBuffer.concat` — Tamper Resistance
+## 40. `SharedArrayBuffer.fromList` — Tamper Resistance
 
 ### 40.1 Overridden `.byteLength` on SharedArrayBuffer items
 
@@ -2584,17 +2584,17 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   const sab = new SharedArrayBuffer(4);
   new Uint8Array(sab).set([1, 2, 3, 4]);
   Object.defineProperty(sab, 'byteLength', { value: 100 });
-  const result = SharedArrayBuffer.concat([sab]);
+  const result = SharedArrayBuffer.fromList([sab]);
   result.byteLength // → 4 (uses [[ArrayBufferByteLength]], not .byteLength)
   ```
 
 ### 40.2 Overridden properties on TypedArray items
 
-- [ ] [40.2.1] Overridden `.byteLength` on TypedArray passed to `SharedArrayBuffer.concat`:
+- [ ] [40.2.1] Overridden `.byteLength` on TypedArray passed to `SharedArrayBuffer.fromList`:
   ```js
   const u8 = new Uint8Array([1, 2, 3, 4]);
   Object.defineProperty(u8, 'byteLength', { value: 100 });
-  const result = SharedArrayBuffer.concat([u8]);
+  const result = SharedArrayBuffer.fromList([u8]);
   result.byteLength // → 4
   ```
 
@@ -2604,13 +2604,13 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
   ```js
   let callCount = 0;
   const opts = { get length() { callCount++; return 4; } };
-  SharedArrayBuffer.concat([new SharedArrayBuffer(2)], opts);
+  SharedArrayBuffer.fromList([new SharedArrayBuffer(2)], opts);
   callCount // → 1
   ```
 - [ ] [40.3.2] Options object with getter on `growable` that throws:
   ```js
   const opts = { get growable() { throw new Error('boom'); } };
-  SharedArrayBuffer.concat([], opts) // → Error('boom')
+  SharedArrayBuffer.fromList([], opts) // → Error('boom')
   ```
 
 ### 40.4 Prototype pollution
@@ -2622,7 +2622,7 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
     Object.defineProperty(SharedArrayBuffer.prototype, 'byteLength', { get() { return 9999; } });
     const sab = new SharedArrayBuffer(4);
     new Uint8Array(sab).set([1, 2, 3, 4]);
-    const result = SharedArrayBuffer.concat([sab]);
+    const result = SharedArrayBuffer.fromList([sab]);
     result.byteLength // → 4
   } finally {
     Object.defineProperty(SharedArrayBuffer.prototype, 'byteLength', origDesc);
@@ -2631,16 +2631,16 @@ Note: As with §4 and §10, creating buffers large enough to trigger this may be
 
 ---
 
-## 41. `SharedArrayBuffer.concat` — Items Iterable Variations
+## 41. `SharedArrayBuffer.fromList` — Items Iterable Variations
 
-- [ ] [41.1.1] Plain Array: `SharedArrayBuffer.concat([new SharedArrayBuffer(2), new SharedArrayBuffer(2)])` → works
+- [ ] [41.1.1] Plain Array: `SharedArrayBuffer.fromList([new SharedArrayBuffer(2), new SharedArrayBuffer(2)])` → works
 - [ ] [41.1.2] Generator:
   ```js
   function* gen() { yield new SharedArrayBuffer(2); yield new Uint8Array([1, 2]); }
-  SharedArrayBuffer.concat(gen()) // → SharedArrayBuffer of byteLength 4
+  SharedArrayBuffer.fromList(gen()) // → SharedArrayBuffer of byteLength 4
   ```
 - [ ] [41.1.3] Set of mixed types:
   ```js
-  SharedArrayBuffer.concat(new Set([new SharedArrayBuffer(2), new Uint8Array([1, 2]), new DataView(new ArrayBuffer(2))]))
+  SharedArrayBuffer.fromList(new Set([new SharedArrayBuffer(2), new Uint8Array([1, 2]), new DataView(new ArrayBuffer(2))]))
   // → SharedArrayBuffer of byteLength 6
   ```

--- a/TEST_CASES.md
+++ b/TEST_CASES.md
@@ -706,12 +706,37 @@ Covered in §10. Included here as a cross-reference.
 
 ### 16.2 `ArrayBuffer.concat` evaluation order
 
-- [ ] [16.2.1] Items iteration (steps 1���3) occurs before options processing (step 4+):
+- [ ] [16.2.1] Options processing (steps 1–7) occurs before items iteration (step 8, `GetConcatenationSources`):
   ```js
   let iteratorCalled = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
-  try { ArrayBuffer.concat(items, 42); } catch(e) {} // options type check error at step 4
-  iteratorCalled // → true (items iterated at step 3, before options checked at step 4)
+  try { ArrayBuffer.concat(items, 42); } catch(e) {} // options type check error at step 1
+  iteratorCalled // → false (options checked at step 1, before items iterated at step 8)
+  ```
+- [ ] [16.2.2] Options property access occurs before items iteration:
+  ```js
+  let iteratorCalled = false;
+  let optionsAccessed = false;
+  const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
+  const options = { get length() { optionsAccessed = true; return 0; } };
+  ArrayBuffer.concat(items, options);
+  optionsAccessed // → true
+  iteratorCalled // → true
+  // optionsAccessed becomes true before iteratorCalled
+  ```
+- [ ] [16.2.3] `resizable`/`immutable` mutual exclusion check (step 7) occurs before item iteration/validation (step 8):
+  ```js
+  let iteratorCalled = false;
+  const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
+  try { ArrayBuffer.concat(items, { resizable: true, immutable: true }); } catch(e) {} // → TypeError (mutual exclusion)
+  iteratorCalled // → false (mutual exclusion checked before iteration)
+  ```
+- [ ] [16.2.4] Length validation occurs before items iteration:
+  ```js
+  let iteratorCalled = false;
+  const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
+  try { ArrayBuffer.concat(items, { length: 'bad' }); } catch(e) {} // → TypeError from length validation
+  iteratorCalled // → false (length validated before iteration)
   ```
 - [ ] [16.2.2] Options processing (steps 4–10) occurs before item validation (step 11, `GetConcatenationSources`):
   ```js
@@ -728,25 +753,62 @@ Covered in §10. Included here as a cross-reference.
 
 ### 16.3 `SharedArrayBuffer.concat` evaluation order
 
-- [ ] [16.3.1] Items iteration (steps 1–3) occurs before options processing (step 4+):
+- [ ] [16.3.1] Options processing (steps 1–6) occurs before items iteration (step 7, `GetConcatenationSources`):
   ```js
   let iteratorCalled = false;
   const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
-  try { SharedArrayBuffer.concat(items, 42); } catch(e) {} // options type check error at step 4
-  iteratorCalled // → true (items iterated at step 3, before options checked at step 4)
+  try { SharedArrayBuffer.concat(items, 42); } catch(e) {} // options type check error at step 1
+  iteratorCalled // → false (options checked at step 1, before items iterated at step 7)
   ```
-- [ ] [16.3.2] Options processing (steps 4–9) occurs before item validation (step 10, `GetConcatenationSources`):
+- [ ] [16.3.2] Options property access occurs before items iteration:
   ```js
-  const detached = new ArrayBuffer(4);
-  detached.transfer();
-  SharedArrayBuffer.concat([detached], { length: 'bad' }) // → TypeError from length validation (step 7)
+  let iteratorCalled = false;
+  let optionsAccessed = false;
+  const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
+  const options = { get length() { optionsAccessed = true; return 0; } };
+  SharedArrayBuffer.concat(items, options);
+  optionsAccessed // → true
+  iteratorCalled // → true
+  // optionsAccessed becomes true before iteratorCalled
+  ```
+- [ ] [16.3.3] Length validation occurs before items iteration:
+  ```js
+  let iteratorCalled = false;
+  const items = { [Symbol.iterator]() { iteratorCalled = true; return [][Symbol.iterator](); } };
+  try { SharedArrayBuffer.concat(items, { length: 'bad' }); } catch(e) {} // → TypeError from length validation
+  iteratorCalled // → false (length validated before iteration)
   ```
 
 ### 16.4 Items iterator with side effects
 
-- [ ] [16.4.1] `%TypedArray%.concat`: Custom iterable that tracks iteration count → all items collected before any validation
-- [ ] [16.4.2] `ArrayBuffer.concat`: Custom iterable that tracks iteration count → all items collected before any validation
-- [ ] [16.4.3] `SharedArrayBuffer.concat`: Custom iterable that tracks iteration count → all items collected before any validation
+- [ ] [16.4.1] `%TypedArray%.concat`: Custom iterable that tracks iteration count → all items collected before any item validation
+- [ ] [16.4.2] `ArrayBuffer.concat`: Custom iterable that tracks iteration count → all items collected before any item validation; options processed before iteration
+- [ ] [16.4.3] `SharedArrayBuffer.concat`: Custom iterable that tracks iteration count → all items collected before any item validation; options processed before iteration
+
+### 16.5 No user code after GetConcatenationSources
+
+- [ ] [16.5.1] `ArrayBuffer.concat`: After items are iterated and validated in GetConcatenationSources, no user code can run:
+  ```js
+  // Options getter cannot affect items after they are collected
+  let phase = 'start';
+  const ab = new ArrayBuffer(4);
+  const items = {
+    [Symbol.iterator]() {
+      phase = 'iterating';
+      return [ab][Symbol.iterator]();
+    }
+  };
+  const options = {
+    get length() {
+      phase = 'options';
+      return undefined;
+    }
+  };
+  ArrayBuffer.concat(items, options);
+  // phase transitions: 'start' → 'options' → 'iterating'
+  // (options accessed first, then iteration happens)
+  ```
+- [ ] [16.5.2] `SharedArrayBuffer.concat`: Same guarantee as ArrayBuffer.concat
 
 ---
 

--- a/spec.emu
+++ b/spec.emu
@@ -32,8 +32,7 @@ contributors: James M Snell
         <emu-alg>
           1. If _value_ is *undefined*, return _default_.
           1. If _value_ is not a Number, throw a *TypeError* exception.
-          1. If _value_ is *NaN*, throw a *RangeError* exception.
-          1. If truncate(ℝ(_value_)) is not ℝ(_value_), throw a *RangeError* exception.
+          1. If _value_ is not an integral Number, throw a *RangeError* exception.
           1. Return ℝ(_value_).
         </emu-alg>
       </emu-clause>
@@ -42,21 +41,22 @@ contributors: James M Snell
     <emu-clause id="sec-properties-of-the-%typedarray%-intrinsic-object">
       <h1>Properties of the %TypedArray% Intrinsic Object</h1>
 
-      <emu-clause id="sec-%typedarray%.concat">
+      <emu-clause id="sec-%typedarray%.concat" type="built-in function">
         <h1>%TypedArray%.concat ( _items_ [ , _length_ ] )</h1>
         <p>This method concatenates the elements of multiple TypedArrays of the same type into a new TypedArray. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _constructor_ be the *this* value.
-          1. If IsConstructor(_constructor_) is *false*, throw a *TypeError* exception.
-          1. If _constructor_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
-          1. Let _arrayList_ be ? IteratorToList(? GetIteratorFromMethod(_items_, ? GetMethod(_items_, %Symbol.iterator%))).
+          1. If _constructor_ does not appear in the Constructor column of <emu-xref href="#table-the-typedarray-constructors"></emu-xref>, throw a *TypeError* exception.
+          1. Let _constructorName_ be the String value of the Constructor Name column of the row in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> whose Constructor column is _constructor_.
+          1. Let _usingIterator_ be ? GetMethod(_items_, %Symbol.iterator%).
+          1. If _usingIterator_ is *undefined*, throw a *TypeError* exception.
+          1. Let _arrayList_ be ? IteratorToList(? GetIteratorFromMethod(_items_, _usingIterator_)).
           1. Let _newLength_ be ~empty~.
           1. If _length_ is present and _length_ is not *undefined*, then
             1. Set _newLength_ to ? ValidateIntegralNumber(_length_, 0).
             1. If _newLength_ &lt; 0, throw a *RangeError* exception.
             1. If _newLength_ &gt; 2<sup>53</sup> - 1, throw a *RangeError* exception.
           1. Let _totalLength_ be 0.
-          1. Let _constructorName_ be _constructor_.[[TypedArrayName]].
           1. For each element _item_ of _arrayList_, do
             1. Let _taRecord_ be ? ValidateTypedArray(_item_, ~seq-cst~).
             1. If _item_.[[TypedArrayName]] is not _constructorName_, throw a *TypeError* exception.
@@ -74,6 +74,7 @@ contributors: James M Snell
             1. Let _remaining_ be _newLength_ - _writeOffset_.
             1. If _remaining_ &gt; 0, then
               1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_item_, ~seq-cst~).
+              1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
               1. Let _itemLength_ be TypedArrayLength(_taRecord_).
               1. Let _count_ be the result of clamping _itemLength_ between 0 and _remaining_.
               1. Let _srcByteOffset_ be _item_.[[ByteOffset]].
@@ -82,6 +83,10 @@ contributors: James M Snell
               1. [id="step-ta-copy-done"] Set _writeOffset_ to _writeOffset_ + _count_.
           1. Return _result_.
         </emu-alg>
+        <p>The *"length"* property of this method is *1*<sub>𝔽</sub>.</p>
+        <emu-note>
+          <p>If _items_ yields no elements, the result is a zero-length TypedArray unless _length_ overrides the total. For example, `Uint8Array.concat([], 10)` produces a 10-element zero-filled Uint8Array.</p>
+        </emu-note>
         <emu-note type="editor">
           <p>The algorithm from <emu-xref href="#step-ta-copy-start"></emu-xref> through <emu-xref href="#step-ta-copy-done"></emu-xref> is specified with explicit allocation and byte-copying steps for clarity. Because all items share the same element type and the copy operates on the underlying data blocks, the result of the concatenation is not observable to user code during construction. Implementations may therefore use any technique — such as bulk memory copy, deferred allocation, or platform-specific optimizations — provided the observable result is equivalent.</p>
         </emu-note>
@@ -101,7 +106,7 @@ contributors: James M Snell
     </h1>
     <dl class="header">
       <dt>description</dt>
-      <dd>It validates each element of _arrayList_ as an ArrayBuffer, SharedArrayBuffer, TypedArray, or DataView, and returns a Record containing a List of source Records (each with [[Buffer]], [[ByteOffset]], and [[ByteLength]] fields) and the total byte length of all sources.</dd>
+      <dd>It validates each element of _arrayList_ as an ArrayBuffer, SharedArrayBuffer, TypedArray, or DataView, and returns a Record containing a List of source Records (each with [[Buffer]], [[ByteOffset]], and [[ByteLength]] fields) and the total byte length of all sources. It performs the following steps when called:</dd>
     </dl>
     <emu-alg>
       1. Let _totalByteLength_ be 0.
@@ -144,12 +149,12 @@ contributors: James M Snell
     </h1>
     <dl class="header">
       <dt>description</dt>
-      <dd>It copies byte data from _sources_ into _result_ in order, stopping when _result_ is full.</dd>
+      <dd>It copies byte data from _sources_ into _result_ in order, stopping when _result_ is full. It performs the following steps when called:</dd>
     </dl>
     <emu-alg>
       1. [id="step-copy-start"] Let _writeOffset_ be 0.
       1. For each element _source_ of _sources_, do
-        1. Let _remaining_ be _result_.[[ArrayBufferByteLength]] - _writeOffset_.
+        1. Let _remaining_ be ArrayBufferByteLength(_result_, ~seq-cst~) - _writeOffset_.
         1. If _remaining_ &gt; 0, then
           1. Let _sourceBuffer_ be _source_.[[Buffer]].
           1. Let _sourceByteOffset_ be _source_.[[ByteOffset]].
@@ -159,6 +164,9 @@ contributors: James M Snell
           1. [id="step-copy-done"] Set _writeOffset_ to _writeOffset_ + _count_.
       1. Return ~unused~.
     </emu-alg>
+    <emu-note>
+      <p>The callers of this abstract operation (ArrayBuffer.concat and SharedArrayBuffer.concat) allocate _result_ using the intrinsic %ArrayBuffer% or %SharedArrayBuffer% constructors, whose *"prototype"* properties are non-configurable data properties. No user code can execute between the validation of sources in GetConcatenationSources and the byte copying performed here. Therefore, no source buffer can become detached during this operation.</p>
+    </emu-note>
     <emu-note type="editor">
       <p>The algorithm from <emu-xref href="#step-copy-start"></emu-xref> through <emu-xref href="#step-copy-done"></emu-xref> is specified with explicit byte-copying steps for clarity. Because the copy operates on the underlying data blocks, the result of the concatenation is not observable to user code during construction. Implementations may therefore use any technique — such as bulk memory copy, deferred allocation, or platform-specific optimizations — provided the observable result is equivalent.</p>
     </emu-note>
@@ -180,6 +188,7 @@ contributors: James M Snell
     </dl>
     <emu-alg>
       1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
+      1. Assert: _arrayBuffer_ is not a SharedArrayBuffer.
       1. NOTE: The concrete steps for this abstract operation will be provided by the Immutable ArrayBuffer proposal.
       1. Return ~unused~.
     </emu-alg>
@@ -191,25 +200,27 @@ contributors: James M Snell
   <emu-clause id="sec-properties-of-the-arraybuffer-constructor">
     <h1>Properties of the ArrayBuffer Constructor</h1>
 
-    <emu-clause id="sec-arraybuffer.concat">
+    <emu-clause id="sec-arraybuffer.concat" type="built-in function">
       <h1>ArrayBuffer.concat ( _items_ [ , _options_ ] )</h1>
       <p>This method concatenates the byte contents of multiple ArrayBuffers, SharedArrayBuffers, TypedArrays, or DataViews into a new ArrayBuffer. It performs the following steps when called:</p>
       <emu-alg>
-        1. Let _arrayList_ be ? IteratorToList(? GetIteratorFromMethod(_items_, ? GetMethod(_items_, %Symbol.iterator%))).
-        1. If _options_ is *undefined*, then
-          1. Let _optionsObj_ be OrdinaryObjectCreate(*null*).
-        1. Else if _options_ is an Object, then
-          1. Let _optionsObj_ be _options_.
+        1. Let _usingIterator_ be ? GetMethod(_items_, %Symbol.iterator%).
+        1. If _usingIterator_ is *undefined*, throw a *TypeError* exception.
+        1. Let _arrayList_ be ? IteratorToList(? GetIteratorFromMethod(_items_, _usingIterator_)).
+        1. If _options_ is not *undefined* and _options_ is not an Object, throw a *TypeError* exception.
+        1. If _options_ is an Object, then
+          1. Let _lengthOption_ be ? Get(_options_, *"length"*).
+          1. Let _resizable_ be ToBoolean(? Get(_options_, *"resizable"*)).
+          1. Let _immutable_ be ToBoolean(? Get(_options_, *"immutable"*)).
         1. Else,
-          1. Throw a *TypeError* exception.
-        1. Let _lengthOption_ be ? Get(_optionsObj_, *"length"*).
+          1. Let _lengthOption_ be *undefined*.
+          1. Let _resizable_ be *false*.
+          1. Let _immutable_ be *false*.
         1. Let _newByteLength_ be ~empty~.
         1. If _lengthOption_ is not *undefined*, then
           1. Set _newByteLength_ to ? ValidateIntegralNumber(_lengthOption_, 0).
           1. If _newByteLength_ &lt; 0, throw a *RangeError* exception.
           1. If _newByteLength_ &gt; 2<sup>53</sup> - 1, throw a *RangeError* exception.
-        1. Let _resizable_ be ToBoolean(? Get(_optionsObj_, *"resizable"*)).
-        1. Let _immutable_ be ToBoolean(? Get(_optionsObj_, *"immutable"*)).
         1. If _resizable_ is *true* and _immutable_ is *true*, throw a *TypeError* exception.
         1. Let _concatenation_ be ? GetConcatenationSources(_arrayList_).
         1. Let _sources_ be _concatenation_.[[Sources]].
@@ -227,6 +238,7 @@ contributors: James M Snell
           1. Perform MakeArrayBufferImmutable(_result_).
         1. Return _result_.
       </emu-alg>
+      <p>The *"length"* property of this method is *1*<sub>𝔽</sub>.</p>
       <emu-note type="editor">
         <p>The _immutable_ option depends on the <a href="https://github.com/tc39/proposal-immutable-arraybuffer">Immutable ArrayBuffer proposal</a> (currently at stage 2.7). MakeArrayBufferImmutable is a placeholder for the abstract operation that will be defined by that proposal.</p>
       </emu-note>
@@ -246,24 +258,25 @@ contributors: James M Snell
   <emu-clause id="sec-properties-of-the-sharedarraybuffer-constructor">
     <h1>Properties of the SharedArrayBuffer Constructor</h1>
 
-    <emu-clause id="sec-sharedarraybuffer.concat">
+    <emu-clause id="sec-sharedarraybuffer.concat" type="built-in function">
       <h1>SharedArrayBuffer.concat ( _items_ [ , _options_ ] )</h1>
       <p>This method concatenates the byte contents of multiple ArrayBuffers, SharedArrayBuffers, TypedArrays, or DataViews into a new SharedArrayBuffer. It performs the following steps when called:</p>
       <emu-alg>
-        1. Let _arrayList_ be ? IteratorToList(? GetIteratorFromMethod(_items_, ? GetMethod(_items_, %Symbol.iterator%))).
-        1. If _options_ is *undefined*, then
-          1. Let _optionsObj_ be OrdinaryObjectCreate(*null*).
-        1. Else if _options_ is an Object, then
-          1. Let _optionsObj_ be _options_.
+        1. Let _usingIterator_ be ? GetMethod(_items_, %Symbol.iterator%).
+        1. If _usingIterator_ is *undefined*, throw a *TypeError* exception.
+        1. Let _arrayList_ be ? IteratorToList(? GetIteratorFromMethod(_items_, _usingIterator_)).
+        1. If _options_ is not *undefined* and _options_ is not an Object, throw a *TypeError* exception.
+        1. If _options_ is an Object, then
+          1. Let _lengthOption_ be ? Get(_options_, *"length"*).
+          1. Let _growable_ be ToBoolean(? Get(_options_, *"growable"*)).
         1. Else,
-          1. Throw a *TypeError* exception.
-        1. Let _lengthOption_ be ? Get(_optionsObj_, *"length"*).
+          1. Let _lengthOption_ be *undefined*.
+          1. Let _growable_ be *false*.
         1. Let _newByteLength_ be ~empty~.
         1. If _lengthOption_ is not *undefined*, then
           1. Set _newByteLength_ to ? ValidateIntegralNumber(_lengthOption_, 0).
           1. If _newByteLength_ &lt; 0, throw a *RangeError* exception.
           1. If _newByteLength_ &gt; 2<sup>53</sup> - 1, throw a *RangeError* exception.
-        1. Let _growable_ be ToBoolean(? Get(_optionsObj_, *"growable"*)).
         1. Let _concatenation_ be ? GetConcatenationSources(_arrayList_).
         1. Let _sources_ be _concatenation_.[[Sources]].
         1. Let _totalByteLength_ be _concatenation_.[[TotalByteLength]].
@@ -278,6 +291,7 @@ contributors: James M Snell
         1. Perform CopySourcesToBuffer(_result_, _sources_).
         1. Return _result_.
       </emu-alg>
+      <p>The *"length"* property of this method is *1*<sub>𝔽</sub>.</p>
       <emu-note>
         <p>The result is always a SharedArrayBuffer regardless of the input types.</p>
         <p>If the optional _options_ object is provided, the *"length"* property controls the byte length of the result. If *"length"* is less than the total byte length of the inputs, the result is truncated. If *"length"* is greater, the result is zero-filled beyond the copied bytes.</p>

--- a/spec.emu
+++ b/spec.emu
@@ -41,9 +41,9 @@ contributors: James M Snell
     <emu-clause id="sec-properties-of-the-%typedarray%-intrinsic-object">
       <h1>Properties of the %TypedArray% Intrinsic Object</h1>
 
-      <emu-clause id="sec-%typedarray%.concat" type="built-in function">
-        <h1>%TypedArray%.concat ( _items_ [ , _length_ ] )</h1>
-        <p>This method concatenates the elements of multiple TypedArrays of the same type into a new TypedArray. It performs the following steps when called:</p>
+      <emu-clause id="sec-%typedarray%.fromlist" type="built-in function" oldids="sec-%typedarray%.concat">
+        <h1>%TypedArray%.fromList ( _items_ [ , _length_ ] )</h1>
+        <p>This method creates a new TypedArray by concatenating the elements of multiple TypedArrays of the same type. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _constructor_ be the *this* value.
           1. If _constructor_ does not appear in the Constructor column of <emu-xref href="#table-the-typedarray-constructors"></emu-xref>, throw a *TypeError* exception.
@@ -85,7 +85,7 @@ contributors: James M Snell
         </emu-alg>
         <p>The *"length"* property of this method is *1*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _items_ yields no elements, the result is a zero-length TypedArray unless _length_ overrides the total. For example, `Uint8Array.concat([], 10)` produces a 10-element zero-filled Uint8Array.</p>
+          <p>If _items_ yields no elements, the result is a zero-length TypedArray unless _length_ overrides the total. For example, `Uint8Array.fromList([], 10)` produces a 10-element zero-filled Uint8Array.</p>
         </emu-note>
         <emu-note type="editor">
           <p>The algorithm from <emu-xref href="#step-ta-copy-start"></emu-xref> through <emu-xref href="#step-ta-copy-done"></emu-xref> is specified with explicit allocation and byte-copying steps for clarity. Because all items share the same element type and the copy operates on the underlying data blocks, the result of the concatenation is not observable to user code during construction. Implementations may therefore use any technique — such as bulk memory copy, deferred allocation, or platform-specific optimizations — provided the observable result is equivalent.</p>
@@ -171,7 +171,7 @@ contributors: James M Snell
       1. Return ~unused~.
     </emu-alg>
     <emu-note>
-      <p>The callers of this abstract operation (ArrayBuffer.concat and SharedArrayBuffer.concat) process options before calling GetConcatenationSources, ensuring that no user code can execute after GetConcatenationSources returns. The callers then allocate _result_ using the intrinsic %ArrayBuffer% or %SharedArrayBuffer% constructors, whose *"prototype"* properties are non-configurable data properties. Therefore, no source buffer can become detached between validation and the byte copying performed here.</p>
+      <p>The callers of this abstract operation (ArrayBuffer.fromList and SharedArrayBuffer.fromList) process options before calling GetConcatenationSources, ensuring that no user code can execute after GetConcatenationSources returns. The callers then allocate _result_ using the intrinsic %ArrayBuffer% or %SharedArrayBuffer% constructors, whose *"prototype"* properties are non-configurable data properties. Therefore, no source buffer can become detached between validation and the byte copying performed here.</p>
     </emu-note>
     <emu-note type="editor">
       <p>The algorithm from <emu-xref href="#step-copy-start"></emu-xref> through <emu-xref href="#step-copy-done"></emu-xref> is specified with explicit byte-copying steps for clarity. Because the copy operates on the underlying data blocks, the result of the concatenation is not observable to user code during construction. Implementations may therefore use any technique — such as bulk memory copy, deferred allocation, or platform-specific optimizations — provided the observable result is equivalent.</p>
@@ -206,9 +206,9 @@ contributors: James M Snell
   <emu-clause id="sec-properties-of-the-arraybuffer-constructor">
     <h1>Properties of the ArrayBuffer Constructor</h1>
 
-    <emu-clause id="sec-arraybuffer.concat" type="built-in function">
-      <h1>ArrayBuffer.concat ( _items_ [ , _options_ ] )</h1>
-      <p>This method concatenates the byte contents of multiple ArrayBuffers, SharedArrayBuffers, TypedArrays, or DataViews into a new ArrayBuffer. It performs the following steps when called:</p>
+    <emu-clause id="sec-arraybuffer.fromlist" type="built-in function" oldids="sec-arraybuffer.concat">
+      <h1>ArrayBuffer.fromList ( _items_ [ , _options_ ] )</h1>
+      <p>This method creates a new ArrayBuffer by concatenating the byte contents of multiple ArrayBuffers, SharedArrayBuffers, TypedArrays, or DataViews. It performs the following steps when called:</p>
       <emu-alg>
         1. If _options_ is not *undefined* and _options_ is not an Object, throw a *TypeError* exception.
         1. If _options_ is an Object, then
@@ -261,9 +261,9 @@ contributors: James M Snell
   <emu-clause id="sec-properties-of-the-sharedarraybuffer-constructor">
     <h1>Properties of the SharedArrayBuffer Constructor</h1>
 
-    <emu-clause id="sec-sharedarraybuffer.concat" type="built-in function">
-      <h1>SharedArrayBuffer.concat ( _items_ [ , _options_ ] )</h1>
-      <p>This method concatenates the byte contents of multiple ArrayBuffers, SharedArrayBuffers, TypedArrays, or DataViews into a new SharedArrayBuffer. It performs the following steps when called:</p>
+    <emu-clause id="sec-sharedarraybuffer.fromlist" type="built-in function" oldids="sec-sharedarraybuffer.concat">
+      <h1>SharedArrayBuffer.fromList ( _items_ [ , _options_ ] )</h1>
+      <p>This method creates a new SharedArrayBuffer by concatenating the byte contents of multiple ArrayBuffers, SharedArrayBuffers, TypedArrays, or DataViews. It performs the following steps when called:</p>
       <emu-alg>
         1. If _options_ is not *undefined* and _options_ is not an Object, throw a *TypeError* exception.
         1. If _options_ is an Object, then

--- a/spec.emu
+++ b/spec.emu
@@ -101,14 +101,17 @@ contributors: James M Snell
   <emu-clause id="sec-getconcatenationsources" type="abstract operation">
     <h1>
       GetConcatenationSources (
-        _arrayList_: a List of ECMAScript language values,
+        _items_: an ECMAScript language value,
       ): either a normal completion containing a Record with fields [[Sources]] (a List of Records) and [[TotalByteLength]] (a non-negative integer), or a throw completion
     </h1>
     <dl class="header">
       <dt>description</dt>
-      <dd>It validates each element of _arrayList_ as an ArrayBuffer, SharedArrayBuffer, TypedArray, or DataView, and returns a Record containing a List of source Records (each with [[Buffer]], [[ByteOffset]], and [[ByteLength]] fields) and the total byte length of all sources. It performs the following steps when called:</dd>
+      <dd>It iterates _items_ and validates each element as an ArrayBuffer, SharedArrayBuffer, TypedArray, or DataView, and returns a Record containing a List of source Records (each with [[Buffer]], [[ByteOffset]], and [[ByteLength]] fields) and the total byte length of all sources. It performs the following steps when called:</dd>
     </dl>
     <emu-alg>
+      1. Let _usingIterator_ be ? GetMethod(_items_, %Symbol.iterator%).
+      1. If _usingIterator_ is *undefined*, throw a *TypeError* exception.
+      1. Let _arrayList_ be ? IteratorToList(? GetIteratorFromMethod(_items_, _usingIterator_)).
       1. Let _totalByteLength_ be 0.
       1. Let _sources_ be a new empty List.
       1. For each element _item_ of _arrayList_, do
@@ -138,6 +141,9 @@ contributors: James M Snell
     <emu-note>
       <p>For TypedArray and DataView inputs, only the viewed portion of the underlying buffer is included. The byte lengths are snapshotted with ~seq-cst~ ordering at the time each item is validated.</p>
     </emu-note>
+    <emu-note>
+      <p>After this abstract operation returns, all source buffers have been validated and their byte lengths snapshotted. No user code can execute between this point and the completion of byte copying by CopySourcesToBuffer. This ensures that no source buffer can become detached or resized during the copy operation.</p>
+    </emu-note>
   </emu-clause>
 
   <emu-clause id="sec-copysourcestobuffer" type="abstract operation">
@@ -165,7 +171,7 @@ contributors: James M Snell
       1. Return ~unused~.
     </emu-alg>
     <emu-note>
-      <p>The callers of this abstract operation (ArrayBuffer.concat and SharedArrayBuffer.concat) allocate _result_ using the intrinsic %ArrayBuffer% or %SharedArrayBuffer% constructors, whose *"prototype"* properties are non-configurable data properties. No user code can execute between the validation of sources in GetConcatenationSources and the byte copying performed here. Therefore, no source buffer can become detached during this operation.</p>
+      <p>The callers of this abstract operation (ArrayBuffer.concat and SharedArrayBuffer.concat) process options before calling GetConcatenationSources, ensuring that no user code can execute after GetConcatenationSources returns. The callers then allocate _result_ using the intrinsic %ArrayBuffer% or %SharedArrayBuffer% constructors, whose *"prototype"* properties are non-configurable data properties. Therefore, no source buffer can become detached between validation and the byte copying performed here.</p>
     </emu-note>
     <emu-note type="editor">
       <p>The algorithm from <emu-xref href="#step-copy-start"></emu-xref> through <emu-xref href="#step-copy-done"></emu-xref> is specified with explicit byte-copying steps for clarity. Because the copy operates on the underlying data blocks, the result of the concatenation is not observable to user code during construction. Implementations may therefore use any technique — such as bulk memory copy, deferred allocation, or platform-specific optimizations — provided the observable result is equivalent.</p>
@@ -204,9 +210,6 @@ contributors: James M Snell
       <h1>ArrayBuffer.concat ( _items_ [ , _options_ ] )</h1>
       <p>This method concatenates the byte contents of multiple ArrayBuffers, SharedArrayBuffers, TypedArrays, or DataViews into a new ArrayBuffer. It performs the following steps when called:</p>
       <emu-alg>
-        1. Let _usingIterator_ be ? GetMethod(_items_, %Symbol.iterator%).
-        1. If _usingIterator_ is *undefined*, throw a *TypeError* exception.
-        1. Let _arrayList_ be ? IteratorToList(? GetIteratorFromMethod(_items_, _usingIterator_)).
         1. If _options_ is not *undefined* and _options_ is not an Object, throw a *TypeError* exception.
         1. If _options_ is an Object, then
           1. Let _lengthOption_ be ? Get(_options_, *"length"*).
@@ -222,7 +225,7 @@ contributors: James M Snell
           1. If _newByteLength_ &lt; 0, throw a *RangeError* exception.
           1. If _newByteLength_ &gt; 2<sup>53</sup> - 1, throw a *RangeError* exception.
         1. If _resizable_ is *true* and _immutable_ is *true*, throw a *TypeError* exception.
-        1. Let _concatenation_ be ? GetConcatenationSources(_arrayList_).
+        1. Let _concatenation_ be ? GetConcatenationSources(_items_).
         1. Let _sources_ be _concatenation_.[[Sources]].
         1. Let _totalByteLength_ be _concatenation_.[[TotalByteLength]].
         1. If _newByteLength_ is ~empty~, then
@@ -262,9 +265,6 @@ contributors: James M Snell
       <h1>SharedArrayBuffer.concat ( _items_ [ , _options_ ] )</h1>
       <p>This method concatenates the byte contents of multiple ArrayBuffers, SharedArrayBuffers, TypedArrays, or DataViews into a new SharedArrayBuffer. It performs the following steps when called:</p>
       <emu-alg>
-        1. Let _usingIterator_ be ? GetMethod(_items_, %Symbol.iterator%).
-        1. If _usingIterator_ is *undefined*, throw a *TypeError* exception.
-        1. Let _arrayList_ be ? IteratorToList(? GetIteratorFromMethod(_items_, _usingIterator_)).
         1. If _options_ is not *undefined* and _options_ is not an Object, throw a *TypeError* exception.
         1. If _options_ is an Object, then
           1. Let _lengthOption_ be ? Get(_options_, *"length"*).
@@ -277,7 +277,7 @@ contributors: James M Snell
           1. Set _newByteLength_ to ? ValidateIntegralNumber(_lengthOption_, 0).
           1. If _newByteLength_ &lt; 0, throw a *RangeError* exception.
           1. If _newByteLength_ &gt; 2<sup>53</sup> - 1, throw a *RangeError* exception.
-        1. Let _concatenation_ be ? GetConcatenationSources(_arrayList_).
+        1. Let _concatenation_ be ? GetConcatenationSources(_items_).
         1. Let _sources_ be _concatenation_.[[Sources]].
         1. Let _totalByteLength_ be _concatenation_.[[TotalByteLength]].
         1. If _newByteLength_ is ~empty~, then


### PR DESCRIPTION
spec.emu:
- Use Table 70 lookup for receiver validation instead of [[TypedArrayName]] slot
- Add explicit GetMethod/undefined check for items iterator (all 3 methods)
- Add IsTypedArrayOutOfBounds re-check in %TypedArray%.concat copy loop
- Use "integral Number" concept in ValidateIntegralNumber (replaces NaN + truncate checks)
- Use ArrayBufferByteLength() AO in CopySourcesToBuffer (not raw slot access)
- Restructure options handling: remove OrdinaryObjectCreate(null), use if/else
- Add type="built-in function" to all 3 concat clauses
- Add "length" property definitions for all 3 methods
- Add NOTE about detachment safety in CopySourcesToBuffer
- Add NOTE about empty iterable edge case in %TypedArray%.concat
- Add Assert that MakeArrayBufferImmutable is not called on SharedArrayBuffer
- Add "It performs the following steps when called:" to AO descriptions

TEST_CASES.md:
- Fix [9.2.4]: null options is TypeError (not accepted)
- Fix [25.6.1]: subclass constructors not in Table 70, clear TypeError
- Fix section 1.2 heading to reference Table 70
- Add Symbol.iterator=null tests for all 3 methods
- Add null options test for SharedArrayBuffer.concat
- Clean up evaluation order section with correct step references